### PR TITLE
Refactor auth pages and add routing tests

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,21 +1,20 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { useAppSelector } from "./store/store";
-import { useMe, useLogin, useRegister } from "./hooks/useAuthQuery";
-import Header from "./components/Header/Header";
-import DayCard from "./components/DayCard/DayCard";
-import ChatBox from "./components/ChatBox/ChatBox";
+import { useMe } from "./hooks/useAuthQuery";
 import { useGetToday } from "./hooks/usePregnancyQuery";
+import Header from "./components/Header/Header";
+import Footer from "./components/Footer/Footer";
 import Welcome from "./pages/Welcome";
 import Chat from "./pages/Chat";
-import Footer from "./components/Footer/Footer";
+import Login from "./pages/Login";
+import Register from "./pages/Register";
 
 const App = () => {
   const { user, token } = useAppSelector((state) => state.auth);
-  const { dayIndex } = useAppSelector((state) => state.pregnancy);
   const { mode } = useAppSelector((s) => s.theme);
-  const { data: userData, isLoading: userLoading } = useMe();
-  const { data: todayData, isLoading: todayLoading } = useGetToday();
+  const { isLoading: userLoading } = useMe();
+  useGetToday();
 
   // Show loading state
   if (userLoading) {
@@ -38,230 +37,43 @@ const App = () => {
     );
   }
 
-  // Show login/register if not authenticated
-  if (!token || !user) {
-    return (
-      <div className={`app ${mode}`}>
-        <AuthScreen />
-      </div>
-    );
-  }
+  const isAuthenticated = Boolean(token && user);
 
   return (
     <BrowserRouter>
       <div className={`app ${mode}`}>
-        <Header />
+        {isAuthenticated && <Header />}
         <Routes>
-          <Route path="/" element={<Navigate to="/chat" replace />} />
-          <Route path="/chat" element={<Chat />} />
-          <Route path="/welcome" element={<Welcome />} />
+          <Route
+            path="/"
+            element={
+              <Navigate to={isAuthenticated ? "/chat" : "/login"} replace />
+            }
+          />
+          <Route
+            path="/login"
+            element={isAuthenticated ? <Navigate to="/chat" replace /> : <Login />}
+          />
+          <Route
+            path="/register"
+            element={
+              isAuthenticated ? <Navigate to="/chat" replace /> : <Register />
+            }
+          />
+          <Route
+            path="/chat"
+            element={isAuthenticated ? <Chat /> : <Navigate to="/login" replace />}
+          />
+          <Route
+            path="/welcome"
+            element={
+              isAuthenticated ? <Welcome /> : <Navigate to="/login" replace />
+            }
+          />
         </Routes>
-        <Footer />
+        {isAuthenticated && <Footer />}
       </div>
     </BrowserRouter>
-  );
-};
-
-// Simple auth screen component
-const AuthScreen = () => {
-  const [isLogin, setIsLogin] = React.useState(true);
-  const [formData, setFormData] = React.useState({
-    name: "",
-    email: "",
-    password: "",
-    region: "UK",
-  });
-
-  const loginMutation = useLogin();
-  const registerMutation = useRegister();
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    if (isLogin) {
-      loginMutation.mutate({
-        email: formData.email,
-        password: formData.password,
-      });
-    } else {
-      registerMutation.mutate(formData);
-    }
-  };
-
-  const handleChange = (e) => {
-    setFormData((prev) => ({
-      ...prev,
-      [e.target.name]: e.target.value,
-    }));
-  };
-
-  return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
-        padding: "1rem",
-      }}
-    >
-      <div
-        style={{
-          background: "white",
-          padding: "2rem",
-          borderRadius: "1rem",
-          boxShadow: "0 10px 25px rgba(0, 0, 0, 0.2)",
-          width: "100%",
-          maxWidth: "400px",
-        }}
-      >
-        <div style={{ textAlign: "center", marginBottom: "2rem" }}>
-          <h1 style={{ color: "#667eea", marginBottom: "0.5rem" }}>PregChat</h1>
-          <p style={{ color: "#666" }}>Your Pregnancy Wellness Guide</p>
-        </div>
-
-        <form onSubmit={handleSubmit}>
-          {!isLogin && (
-            <div style={{ marginBottom: "1rem" }}>
-              <label
-                htmlFor="name"
-                style={{
-                  display: "block",
-                  marginBottom: "0.5rem",
-                  fontWeight: "500",
-                }}
-              >
-                Name
-              </label>
-              <input
-                type="text"
-                id="name"
-                name="name"
-                value={formData.name}
-                onChange={handleChange}
-                className="input"
-                required={!isLogin}
-              />
-            </div>
-          )}
-
-          <div style={{ marginBottom: "1rem" }}>
-            <label
-              htmlFor="email"
-              style={{
-                display: "block",
-                marginBottom: "0.5rem",
-                fontWeight: "500",
-              }}
-            >
-              Email
-            </label>
-            <input
-              type="email"
-              id="email"
-              name="email"
-              value={formData.email}
-              onChange={handleChange}
-              className="input"
-              required
-            />
-          </div>
-
-          <div style={{ marginBottom: "1rem" }}>
-            <label
-              htmlFor="password"
-              style={{
-                display: "block",
-                marginBottom: "0.5rem",
-                fontWeight: "500",
-              }}
-            >
-              Password
-            </label>
-            <input
-              type="password"
-              id="password"
-              name="password"
-              value={formData.password}
-              onChange={handleChange}
-              className="input"
-              required
-            />
-          </div>
-
-          {!isLogin && (
-            <div style={{ marginBottom: "1.5rem" }}>
-              <label
-                htmlFor="region"
-                style={{
-                  display: "block",
-                  marginBottom: "0.5rem",
-                  fontWeight: "500",
-                }}
-              >
-                Region
-              </label>
-              <select
-                id="region"
-                name="region"
-                value={formData.region}
-                onChange={handleChange}
-                className="input"
-              >
-                <option value="UK">United Kingdom</option>
-                <option value="US">United States</option>
-                <option value="Global">Global</option>
-              </select>
-            </div>
-          )}
-
-          {(loginMutation.isError || registerMutation.isError) && (
-            <div
-              style={{
-                background: "#f8d7da",
-                color: "#721c24",
-                padding: "0.75rem",
-                borderRadius: "0.25rem",
-                marginBottom: "1rem",
-                fontSize: "0.875rem",
-              }}
-            >
-              {loginMutation.error?.message || registerMutation.error?.message}
-            </div>
-          )}
-
-          <button
-            type="submit"
-            className="btn"
-            style={{ width: "100%", marginBottom: "1rem" }}
-            disabled={loginMutation.isPending || registerMutation.isPending}
-          >
-            {loginMutation.isPending || registerMutation.isPending
-              ? "Loading..."
-              : isLogin
-              ? "Login"
-              : "Register"}
-          </button>
-
-          <button
-            type="button"
-            onClick={() => setIsLogin(!isLogin)}
-            style={{
-              background: "none",
-              border: "none",
-              color: "#667eea",
-              cursor: "pointer",
-              width: "100%",
-              fontSize: "0.875rem",
-            }}
-          >
-            {isLogin
-              ? "Don't have an account? Register"
-              : "Already have an account? Login"}
-          </button>
-        </form>
-      </div>
-    </div>
   );
 };
 

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
+expect.extend(matchers);
+import React from "react";
+import { fireEvent, render, screen, cleanup } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import App from "./App";
+import authReducer from "./store/slices/authSlice";
+import pregnancyReducer from "./store/slices/pregnancySlice";
+import uiReducer from "./store/slices/uiSlice";
+import chatReducer from "./store/slices/chatSlice";
+import themeReducer from "./store/slices/themeSlice";
+
+const loginMutate = vi.fn();
+const registerMutate = vi.fn();
+
+vi.mock("./hooks/useAuthQuery", () => ({
+  useMe: () => ({ data: null, isLoading: false }),
+  useLogin: () => ({
+    mutate: loginMutate,
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+  useRegister: () => ({
+    mutate: registerMutate,
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+vi.mock("./hooks/usePregnancyQuery", () => ({
+  useGetToday: () => ({ data: null, isLoading: false }),
+}));
+
+const createTestStore = (authState) => {
+  return configureStore({
+    reducer: {
+      auth: authReducer,
+      pregnancy: pregnancyReducer,
+      ui: uiReducer,
+      chat: chatReducer,
+      theme: themeReducer,
+    },
+    preloadedState: authState
+      ? {
+          auth: {
+            ...authReducer(undefined, { type: "@@INIT" }),
+            ...authState,
+          },
+        }
+      : undefined,
+  });
+};
+
+const renderApp = (route = "/login", authState) => {
+  const store = createTestStore(authState);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+      mutations: { retry: false },
+    },
+  });
+
+  window.history.pushState({}, "", route);
+
+  return render(
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </Provider>
+  );
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("App routing", () => {
+  it("renders login route and submits credentials", () => {
+    renderApp("/login");
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: "password123" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /login/i }));
+
+    expect(loginMutate).toHaveBeenCalledWith({
+      email: "test@example.com",
+      password: "password123",
+    });
+  });
+
+  it("renders register route and submits details", () => {
+    renderApp("/register");
+
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: "Test User" },
+    });
+    fireEvent.change(screen.getByLabelText(/^email$/i), {
+      target: { value: "tester@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: "securepass" },
+    });
+    fireEvent.change(screen.getByLabelText(/region/i), {
+      target: { value: "US" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /register/i }));
+
+    expect(registerMutate).toHaveBeenCalledWith({
+      name: "Test User",
+      email: "tester@example.com",
+      password: "securepass",
+      region: "US",
+    });
+  });
+
+  it("redirects unauthenticated users to login when visiting chat", () => {
+    renderApp("/chat");
+
+    expect(
+      screen.getByRole("heading", { name: /welcome back/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /login/i })).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,0 +1,146 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import { useLogin } from "../hooks/useAuthQuery";
+
+const Login = () => {
+  const [formData, setFormData] = useState({
+    email: "",
+    password: "",
+  });
+
+  const loginMutation = useLogin();
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    loginMutation.mutate({
+      email: formData.email,
+      password: formData.password,
+    });
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
+        padding: "1rem",
+      }}
+    >
+      <div
+        style={{
+          background: "white",
+          padding: "2rem",
+          borderRadius: "1rem",
+          boxShadow: "0 10px 25px rgba(0, 0, 0, 0.2)",
+          width: "100%",
+          maxWidth: "400px",
+        }}
+      >
+        <div style={{ textAlign: "center", marginBottom: "2rem" }}>
+          <h1 style={{ color: "#667eea", marginBottom: "0.5rem" }}>
+            Welcome Back
+          </h1>
+          <p style={{ color: "#666", marginBottom: "0.5rem" }}>
+            Sign in to PregChat
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: "1rem" }}>
+            <label
+              htmlFor="email"
+              style={{
+                display: "block",
+                marginBottom: "0.5rem",
+                fontWeight: "500",
+              }}
+            >
+              Email
+            </label>
+            <input
+              type="email"
+              id="email"
+              name="email"
+              value={formData.email}
+              onChange={handleChange}
+              className="input"
+              required
+            />
+          </div>
+
+          <div style={{ marginBottom: "1.5rem" }}>
+            <label
+              htmlFor="password"
+              style={{
+                display: "block",
+                marginBottom: "0.5rem",
+                fontWeight: "500",
+              }}
+            >
+              Password
+            </label>
+            <input
+              type="password"
+              id="password"
+              name="password"
+              value={formData.password}
+              onChange={handleChange}
+              className="input"
+              required
+            />
+          </div>
+
+          {loginMutation.isError && (
+            <div
+              style={{
+                background: "#f8d7da",
+                color: "#721c24",
+                padding: "0.75rem",
+                borderRadius: "0.25rem",
+                marginBottom: "1rem",
+                fontSize: "0.875rem",
+              }}
+            >
+              {loginMutation.error?.message}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className="btn"
+            style={{ width: "100%", marginBottom: "1rem" }}
+            disabled={loginMutation.isPending}
+          >
+            {loginMutation.isPending ? "Loading..." : "Login"}
+          </button>
+        </form>
+
+        <p
+          style={{
+            textAlign: "center",
+            fontSize: "0.875rem",
+            color: "#555",
+          }}
+        >
+          Don't have an account? {" "}
+          <Link to="/register" style={{ color: "#667eea" }}>
+            Register
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -1,0 +1,191 @@
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import { useRegister } from "../hooks/useAuthQuery";
+
+const Register = () => {
+  const [formData, setFormData] = useState({
+    name: "",
+    email: "",
+    password: "",
+    region: "UK",
+  });
+
+  const registerMutation = useRegister();
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    registerMutation.mutate(formData);
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
+        padding: "1rem",
+      }}
+    >
+      <div
+        style={{
+          background: "white",
+          padding: "2rem",
+          borderRadius: "1rem",
+          boxShadow: "0 10px 25px rgba(0, 0, 0, 0.2)",
+          width: "100%",
+          maxWidth: "400px",
+        }}
+      >
+        <div style={{ textAlign: "center", marginBottom: "2rem" }}>
+          <h1 style={{ color: "#667eea", marginBottom: "0.5rem" }}>
+            Create Your Account
+          </h1>
+          <p style={{ color: "#666", marginBottom: "0.5rem" }}>
+            Join PregChat today
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: "1rem" }}>
+            <label
+              htmlFor="name"
+              style={{
+                display: "block",
+                marginBottom: "0.5rem",
+                fontWeight: "500",
+              }}
+            >
+              Name
+            </label>
+            <input
+              type="text"
+              id="name"
+              name="name"
+              value={formData.name}
+              onChange={handleChange}
+              className="input"
+              required
+            />
+          </div>
+
+          <div style={{ marginBottom: "1rem" }}>
+            <label
+              htmlFor="email"
+              style={{
+                display: "block",
+                marginBottom: "0.5rem",
+                fontWeight: "500",
+              }}
+            >
+              Email
+            </label>
+            <input
+              type="email"
+              id="email"
+              name="email"
+              value={formData.email}
+              onChange={handleChange}
+              className="input"
+              required
+            />
+          </div>
+
+          <div style={{ marginBottom: "1rem" }}>
+            <label
+              htmlFor="password"
+              style={{
+                display: "block",
+                marginBottom: "0.5rem",
+                fontWeight: "500",
+              }}
+            >
+              Password
+            </label>
+            <input
+              type="password"
+              id="password"
+              name="password"
+              value={formData.password}
+              onChange={handleChange}
+              className="input"
+              required
+            />
+          </div>
+
+          <div style={{ marginBottom: "1.5rem" }}>
+            <label
+              htmlFor="region"
+              style={{
+                display: "block",
+                marginBottom: "0.5rem",
+                fontWeight: "500",
+              }}
+            >
+              Region
+            </label>
+            <select
+              id="region"
+              name="region"
+              value={formData.region}
+              onChange={handleChange}
+              className="input"
+            >
+              <option value="UK">United Kingdom</option>
+              <option value="US">United States</option>
+              <option value="Global">Global</option>
+            </select>
+          </div>
+
+          {registerMutation.isError && (
+            <div
+              style={{
+                background: "#f8d7da",
+                color: "#721c24",
+                padding: "0.75rem",
+                borderRadius: "0.25rem",
+                marginBottom: "1rem",
+                fontSize: "0.875rem",
+              }}
+            >
+              {registerMutation.error?.message}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className="btn"
+            style={{ width: "100%", marginBottom: "1rem" }}
+            disabled={registerMutation.isPending}
+          >
+            {registerMutation.isPending ? "Loading..." : "Register"}
+          </button>
+        </form>
+
+        <p
+          style={{
+            textAlign: "center",
+            fontSize: "0.875rem",
+            color: "#555",
+          }}
+        >
+          Already have an account? {" "}
+          <Link to="/login" style={{ color: "#667eea" }}>
+            Login
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default Register;

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -15,4 +15,7 @@ export default defineConfig({
   define: {
     global: "globalThis",
   },
+  test: {
+    environment: "jsdom",
+  },
 });


### PR DESCRIPTION
## Summary
- move login and register flows into dedicated pages with explicit routes and redirects
- update the app router to protect chat and welcome pages behind authentication
- add a vitest suite covering auth route behavior and configure the test runner for jsdom

## Testing
- npm --prefix client run test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d0ba3028248330b240f44051d232b9