### PR TITLE
Enhance chat input readability and feedback

### DIFF
--- a/client/src/components/ChatBox/chatBox.styles.scss
+++ b/client/src/components/ChatBox/chatBox.styles.scss
@@ -260,11 +260,54 @@
   color: var(--text);
   border: 0;
   outline: none;
-  font-size: 15px;
-  padding: 8px 4px;
+  font-size: 16px;
+  padding: 10px 4px;
+  caret-color: var(--primary);
+  transition: color 0.3s ease, box-shadow 0.35s ease, background-color 0.35s ease,
+    transform 0.2s ease;
 }
+
 .input::placeholder {
-  color: #7b7b7b;
+  color: var(--muted);
+  opacity: 0.85;
+  transition: color 0.3s ease, opacity 0.3s ease, transform 0.2s ease;
+}
+
+.input:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.02);
+  box-shadow: 0 0 0 4px rgba(26, 115, 232, 0.18);
+  animation: inputFocusGlow 0.45s ease;
+}
+
+.container.light .input:focus-visible {
+  background: rgba(26, 115, 232, 0.05);
+  box-shadow: 0 0 0 4px rgba(26, 115, 232, 0.22);
+}
+
+.container.dark .input:focus-visible {
+  background: rgba(76, 139, 245, 0.08);
+  box-shadow: 0 0 0 4px rgba(76, 139, 245, 0.25);
+}
+
+.input:focus::placeholder,
+.input:focus-visible::placeholder {
+  opacity: 0.6;
+  transform: translateX(2px);
+}
+
+.input:disabled {
+  color: var(--muted);
+}
+
+@keyframes inputFocusGlow {
+  0% {
+    box-shadow: 0 0 0 0 rgba(26, 115, 232, 0.05);
+  }
+
+  100% {
+    box-shadow: 0 0 0 4px rgba(26, 115, 232, 0.18);
+  }
 }
 
 .send {


### PR DESCRIPTION
## Summary
- increase the chat composer input font size and caret contrast for better readability in both themes
- restyle placeholder text and add animated focus feedback to improve usability and affordance

## Testing
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68d0bdde32248330a1e73bb8eb25e3a9