### PR TITLE
Adjust welcome and onboarding layout spacing

### DIFF
--- a/client/src/pages/Onboarding/onboarding.styles.scss
+++ b/client/src/pages/Onboarding/onboarding.styles.scss
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2rem;
+  padding: 2.5rem 0.75rem;
   background: radial-gradient(circle at top, #151515 0%, #080808 55%, #020202 100%);
 }
 
@@ -13,29 +13,41 @@
   background: rgba(12, 12, 12, 0.92);
   border: 1px solid #1f1f1f;
   border-radius: 1rem;
-  padding: 2.5rem;
+  padding: 1rem;
   color: #f3f4ff;
   box-shadow: 0 20px 45px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .onboarding_header {
-  margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 65ch;
+  margin-inline: auto;
 }
 
 .onboarding_title {
   font-size: 2.2rem;
-  margin-bottom: 0.5rem;
+  margin: 0;
+  max-width: 65ch;
+  margin-inline: auto;
 }
 
 .onboarding_subtitle {
   font-size: 1.1rem;
   color: #b5b9c9;
+  margin: 0;
 }
 
 .onboarding_form {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 0.75rem;
+  max-width: 65ch;
+  margin-inline: auto;
 }
 
 .onboarding_field {
@@ -67,7 +79,8 @@
 
 .onboarding_radio_group {
   display: flex;
-  gap: 1.5rem;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
 .onboarding_radio_option {
@@ -84,7 +97,7 @@
 }
 
 .onboarding_submit {
-  margin-top: 0.5rem;
+  margin-top: 0;
   padding: 0.85rem 1.5rem;
   border: none;
   border-radius: 0.75rem;
@@ -94,6 +107,7 @@
   font-size: 1rem;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  align-self: center;
 }
 
 .onboarding_submit:disabled {
@@ -107,17 +121,46 @@
 }
 
 .onboarding_alert {
-  padding: 0.75rem 1rem;
+  padding: 1rem;
   border-radius: 0.75rem;
   background: rgba(255, 107, 129, 0.15);
   border: 1px solid rgba(255, 107, 129, 0.35);
   color: #ffd8df;
+  max-width: 65ch;
+  margin-inline: auto;
 }
 
 .onboarding_loading {
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 160px;
   color: #d0d3dc;
+  max-width: 65ch;
+  margin-inline: auto;
+  padding: 1rem;
+}
+
+@media (min-width: 768px) {
+  .onboarding_page {
+    padding: 3rem 1rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .onboarding_page {
+    padding: 3.5rem 1.5rem;
+  }
+
+  .onboarding_card {
+    padding: 1.25rem;
+    gap: 1rem;
+  }
+
+  .onboarding_form {
+    gap: 1rem;
+  }
+
+  .onboarding_radio_group {
+    gap: 1rem;
+  }
 }

--- a/client/src/pages/Welcome/welcome.styles.scss
+++ b/client/src/pages/Welcome/welcome.styles.scss
@@ -3,7 +3,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2rem;
+  padding: 2.5rem 0.75rem;
   background: radial-gradient(circle at top, #151515 0%, #080808 55%, #020202 100%);
 }
 
@@ -13,45 +13,63 @@
   background: rgba(12, 12, 12, 0.92);
   border: 1px solid #1f1f1f;
   border-radius: 1rem;
-  padding: 3rem;
+  padding: 1rem;
   color: #f3f4ff;
   box-shadow: 0 20px 45px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .welcome_heading {
   font-size: 3rem;
-  margin-bottom: 0.75rem;
   color: #f5f7ff;
+  margin: 0;
+  max-width: 65ch;
+  margin-inline: auto;
 }
 
 .welcome_subheading {
   font-size: 1.2rem;
-  margin-bottom: 2rem;
   color: #9aa0a6;
+  margin: -0.25rem auto 0;
+  max-width: 65ch;
 }
 
 .welcome_intro {
-  margin-bottom: 2rem;
   color: #d0d3dc;
   font-size: 1.05rem;
+  max-width: 65ch;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.welcome_intro p {
+  margin: 0;
 }
 
 .welcome_section {
   background: rgba(28, 32, 42, 0.8);
   border: 1px solid rgba(76, 139, 245, 0.22);
   border-radius: 0.75rem;
-  padding: 2rem;
-  margin-top: 2rem;
+  padding: 1rem;
   color: #e6e8f1;
+  max-width: 65ch;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
 }
 
 .welcome_section h3 {
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.5rem;
   font-size: 1.4rem;
 }
 
 .welcome_section p {
-  margin-bottom: 0.5rem;
+  margin: 0;
   line-height: 1.6;
 }
 
@@ -59,16 +77,24 @@
   background: rgba(24, 24, 24, 0.85);
   border: 1px solid #1f1f1f;
   border-radius: 0.75rem;
-  padding: 2rem;
-  margin-top: 2rem;
+  padding: 1rem;
   color: #d0d3dc;
+  max-width: 65ch;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.welcome_callout p {
+  margin: 0;
 }
 
 .welcome_details {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.5rem;
-  margin-top: 1.5rem;
+  gap: 1rem;
+  margin-top: 1rem;
 }
 
 .welcome_detail_item {
@@ -103,8 +129,9 @@
   color: #fff;
   font-weight: 600;
   text-decoration: none;
-  margin-top: 1rem;
+  margin-top: 0.75rem;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  align-self: center;
 }
 
 .welcome_link:hover {
@@ -113,18 +140,47 @@
 }
 
 .welcome_error {
-  margin-top: 2rem;
-  padding: 1rem 1.25rem;
+  padding: 1rem;
   border-radius: 0.75rem;
   background: rgba(255, 107, 129, 0.15);
   border: 1px solid rgba(255, 107, 129, 0.35);
   color: #ffd8df;
+  max-width: 65ch;
+  margin-inline: auto;
 }
 
 .welcome_loading {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-top: 2rem;
   color: #d0d3dc;
+  max-width: 65ch;
+  margin-inline: auto;
+  padding: 1rem;
+}
+
+@media (min-width: 768px) {
+  .welcome_page {
+    padding: 3rem 1rem;
+  }
+
+  .welcome_details {
+    gap: 1.25rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .welcome_page {
+    padding: 3.5rem 1.5rem;
+  }
+
+  .welcome_card {
+    padding: 1.25rem;
+    gap: 1rem;
+  }
+
+  .welcome_section,
+  .welcome_callout {
+    padding: 1.25rem;
+  }
 }


### PR DESCRIPTION
## Summary
- tighten the Welcome page container with responsive padding, constrained text width, and compact vertical rhythm while preserving the dark styling
- align Onboarding layout spacing with new gutter rules, centered 65ch text blocks, and consistent form gaps across breakpoints

## Testing
- npm run test:client *(cancelled after starting watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_68d0cf625bc883308a471eea217c8b2e