### PR TITLE
Make PregChat header opaque and sticky

### DIFF
--- a/client/src/components/Header/Header.jsx
+++ b/client/src/components/Header/Header.jsx
@@ -18,7 +18,7 @@ const Header = () => {
   const toggleMenu = () => setMenuOpen((v) => !v);
   const closeMenu = () => setMenuOpen(false);
   return (
-    <header className="header">
+    <header className="header" role="banner">
       <div className="topbar">
         <button
           className="menu_btn"

--- a/client/src/components/Header/header.styles.scss
+++ b/client/src/components/Header/header.styles.scss
@@ -13,9 +13,11 @@
 
 .header {
   position: sticky;
-  padding: 1rem;
   top: 0;
-  z-index: 20;
+  z-index: 10;
+  padding: 0.75rem 1rem;
+  background: var(--bg);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 /* Top bar */


### PR DESCRIPTION
## Summary
- give the chat header a solid dark background and subtle border to separate it from messages
- adjust header padding and stacking so it stays pinned at the top of the chat view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0d292215c833094018871e9da64ca