### PR TITLE
Add baby name face-off game with names API

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,6 +8,7 @@ import Footer from "./components/Footer/Footer.jsx";
 import Profile from "./pages/Profile.jsx";
 import Onboarding from "./pages/Onboarding/Onboarding.jsx";
 import Chat from "./pages/Chat.jsx";
+import FaceOffPage from "./pages/FaceOffPage.jsx";
 import Login from "./pages/Login.jsx";
 import Register from "./pages/Register.jsx";
 import Dashboard from "./pages/Dashboard.jsx";
@@ -95,6 +96,16 @@ const App = () => {
             path="/chat"
             element={
               isAuthenticated ? <Chat /> : <Navigate to="/login" replace />
+            }
+          />
+          <Route
+            path="/faceoff"
+            element={
+              isAuthenticated ? (
+                <FaceOffPage />
+              ) : (
+                <Navigate to="/login" replace />
+              )
             }
           />
           <Route

--- a/client/src/components/NameFaceOff/NameFaceOff.jsx
+++ b/client/src/components/NameFaceOff/NameFaceOff.jsx
@@ -1,0 +1,282 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useSearchParams } from "react-router-dom";
+import useNamesQuery from "../../hooks/useNamesQuery.js";
+import { shuffle } from "../../utils/shuffle.js";
+import content from "../../content/appContent.json";
+import "./nameFaceOff.styles.scss";
+
+const STORAGE_KEY = "faceoffState:v1";
+
+const createNamesHash = (list) =>
+  list
+    .reduce((hash, name, index) => {
+      let nextHash = hash;
+      const combined = `${name}-${index}`;
+
+      for (let position = 0; position < combined.length; position += 1) {
+        nextHash = (nextHash << 5) - nextHash + combined.charCodeAt(position);
+        nextHash |= 0;
+      }
+
+      return nextHash;
+    }, 0)
+    .toString(16);
+
+const NameFaceOff = () => {
+  const [searchParams] = useSearchParams();
+  const querySignature = searchParams.toString();
+  const urlSeed = searchParams.get("seed");
+
+  const filters = useMemo(() => {
+    const allowedKeys = ["limit", "gender", "style", "q"];
+    return allowedKeys.reduce((accumulator, key) => {
+      const value = searchParams.get(key);
+      if (value) {
+        accumulator[key] = value;
+      }
+      return accumulator;
+    }, {});
+  }, [querySignature]);
+
+  const { data: names = [], isLoading, isError } = useNamesQuery(filters);
+
+  const [orderedNames, setOrderedNames] = useState([]);
+  const [gameState, setGameState] = useState({
+    champion: "",
+    index: 1,
+    winner: null,
+  });
+  const [initialized, setInitialized] = useState(false);
+  const namesHashRef = useRef("0");
+  const seedRef = useRef(null);
+  const resumedRef = useRef(false);
+
+  useEffect(() => {
+    if (!names.length) {
+      setOrderedNames([]);
+      setGameState({ champion: "", index: 1, winner: null });
+      setInitialized(true);
+      resumedRef.current = false;
+      if (typeof window !== "undefined") {
+        window.localStorage.removeItem(STORAGE_KEY);
+      }
+      return;
+    }
+
+    let storedState = null;
+    if (typeof window !== "undefined") {
+      try {
+        const value = window.localStorage.getItem(STORAGE_KEY);
+        storedState = value ? JSON.parse(value) : null;
+      } catch (error) {
+        storedState = null;
+      }
+    }
+
+    let activeSeed = urlSeed || storedState?.seed || seedRef.current;
+    if (!activeSeed) {
+      activeSeed = `${Date.now()}-${Math.random()}`;
+    }
+    seedRef.current = activeSeed;
+
+    const shuffled = shuffle(names, activeSeed);
+    const namesHash = createNamesHash(shuffled);
+    namesHashRef.current = namesHash;
+
+    const storedIsValid =
+      storedState &&
+      storedState.seed === activeSeed &&
+      storedState.namesHash === namesHash &&
+      typeof storedState.index === "number" &&
+      shuffled.includes(storedState.champion);
+    resumedRef.current = Boolean(storedIsValid);
+
+    const initialChampion = shuffled[0] ?? "";
+    const initialIndex = shuffled.length > 1 ? 1 : shuffled.length;
+    const initialWinner = shuffled.length <= 1 ? initialChampion || null : null;
+
+    const champion = storedIsValid ? storedState.champion : initialChampion;
+    const index = storedIsValid
+      ? Math.min(Math.max(storedState.index, 1), shuffled.length)
+      : initialIndex;
+    const winner = storedIsValid && index >= shuffled.length
+      ? storedState.champion
+      : initialWinner;
+
+    setOrderedNames(shuffled);
+    setGameState({ champion, index, winner });
+    setInitialized(true);
+  }, [names, urlSeed]);
+
+  useEffect(() => {
+    if (!initialized || !orderedNames.length || typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        champion: gameState.champion,
+        index: gameState.index,
+        seed: seedRef.current,
+        namesHash: namesHashRef.current,
+      })
+    );
+  }, [gameState, initialized, orderedNames]);
+
+  const handleKeepChampion = useCallback(() => {
+    setGameState((prev) => {
+      const nextIndex = Math.min(prev.index + 1, orderedNames.length);
+      const winner = nextIndex >= orderedNames.length ? prev.champion : null;
+      return {
+        champion: prev.champion,
+        index: nextIndex,
+        winner,
+      };
+    });
+  }, [orderedNames.length]);
+
+  const handleSelectChallenger = useCallback(() => {
+    setGameState((prev) => {
+      const challenger = orderedNames[prev.index] ?? prev.champion;
+      const nextIndex = Math.min(prev.index + 1, orderedNames.length);
+      const winner = nextIndex >= orderedNames.length ? challenger : null;
+      return {
+        champion: challenger,
+        index: nextIndex,
+        winner,
+      };
+    });
+  }, [orderedNames]);
+
+  const handlePlayAgain = useCallback(() => {
+    if (!names.length) {
+      return;
+    }
+
+    const newSeed = urlSeed || `${Date.now()}-${Math.random()}`;
+    seedRef.current = newSeed;
+    const reshuffled = shuffle(names, newSeed);
+    const namesHash = createNamesHash(reshuffled);
+    namesHashRef.current = namesHash;
+    resumedRef.current = false;
+
+    const champion = reshuffled[0] ?? "";
+    const index = reshuffled.length > 1 ? 1 : reshuffled.length;
+    const winner = reshuffled.length <= 1 ? champion || null : null;
+
+    setOrderedNames(reshuffled);
+    setGameState({ champion, index, winner });
+
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          champion,
+          index,
+          seed: newSeed,
+          namesHash,
+        })
+      );
+    }
+  }, [names, urlSeed]);
+
+  const totalRounds = Math.max(orderedNames.length - 1, 0);
+  const currentRound = Math.min(gameState.index, totalRounds);
+  const challenger = orderedNames[gameState.index] ?? null;
+
+  if (isLoading || !initialized) {
+    return (
+      <div className="name-faceoff__feedback">{content.faceOff.loading}</div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="name-faceoff__feedback">{content.faceOff.error}</div>
+    );
+  }
+
+  if (!orderedNames.length) {
+    return (
+      <div className="name-faceoff__feedback">{content.faceOff.empty}</div>
+    );
+  }
+
+  if (orderedNames.length === 1) {
+    return (
+      <div className="name-faceoff__winner-card">
+        <p className="name-faceoff__progress">{content.faceOff.notEnough}</p>
+        <p className="name-faceoff__winner-name">{orderedNames[0]}</p>
+        <button
+          type="button"
+          className="name-faceoff__play-again"
+          onClick={handlePlayAgain}
+        >
+          {content.faceOff.playAgain}
+        </button>
+      </div>
+    );
+  }
+
+  if (gameState.winner) {
+    return (
+      <div className="name-faceoff__winner-card">
+        <div className="name-faceoff__status">
+          <p>{content.faceOff.winnerTitle}</p>
+          <p className="name-faceoff__winner-name">{gameState.winner}</p>
+        </div>
+        <button
+          type="button"
+          className="name-faceoff__play-again"
+          onClick={handlePlayAgain}
+        >
+          {content.faceOff.playAgain}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="name-faceoff">
+      <div className="name-faceoff__status">
+        <p className="name-faceoff__progress">
+          {`${content.faceOff.progressPrefix} ${Math.max(
+            currentRound,
+            1
+          )} / ${Math.max(totalRounds, 1)}`}
+        </p>
+        {resumedRef.current && (
+          <p className="name-faceoff__resume">{content.faceOff.resume}</p>
+        )}
+      </div>
+      <div className="name-faceoff__matchup">
+        <button
+          type="button"
+          className="name-faceoff__button"
+          onClick={handleKeepChampion}
+        >
+          {`${content.faceOff.championLabel}: ${gameState.champion}`}
+        </button>
+        <button
+          type="button"
+          className="name-faceoff__button name-faceoff__button--challenger"
+          onClick={handleSelectChallenger}
+          disabled={!challenger}
+        >
+          {challenger
+            ? `${content.faceOff.challengerLabel}: ${challenger}`
+            : content.faceOff.waiting}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default NameFaceOff;

--- a/client/src/components/NameFaceOff/nameFaceOff.styles.scss
+++ b/client/src/components/NameFaceOff/nameFaceOff.styles.scss
@@ -1,0 +1,106 @@
+.name-faceoff {
+  display: grid;
+  gap: 1.5rem;
+  justify-items: center;
+  width: 100%;
+}
+
+.name-faceoff__status {
+  text-align: center;
+  color: #f1f3f5;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.name-faceoff__progress {
+  font-size: 0.95rem;
+  color: rgba(241, 243, 245, 0.7);
+}
+
+.name-faceoff__matchup {
+  display: grid;
+  gap: 1rem;
+  width: min(100%, 520px);
+}
+
+.name-faceoff__button {
+  border: none;
+  border-radius: 18px;
+  padding: 1.5rem 1rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  background: linear-gradient(145deg, #232d45, #182235);
+  color: #f8fafc;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+}
+.name-faceoff__button:focus-visible {
+  outline: 3px solid rgba(148, 163, 184, 0.7);
+  outline-offset: 4px;
+}
+
+.name-faceoff__button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.55);
+}
+
+.name-faceoff__button--challenger {
+  background: linear-gradient(145deg, #3b1d36, #2a1427);
+}
+
+.name-faceoff__feedback {
+  text-align: center;
+  color: #f1f3f5;
+  font-size: 1.1rem;
+}
+
+.name-faceoff__winner-card {
+  display: grid;
+  gap: 1.5rem;
+  justify-items: center;
+  padding: 2rem;
+  border-radius: 22px;
+  background: linear-gradient(160deg, #1e293b, #0f172a);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.6);
+  width: min(100%, 520px);
+}
+.name-faceoff__winner-name {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.name-faceoff__play-again {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  background: #f97316;
+  color: #0f172a;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+.name-faceoff__play-again:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(249, 115, 22, 0.35);
+}
+
+.name-faceoff__resume {
+  font-size: 0.9rem;
+  color: rgba(241, 243, 245, 0.65);
+}
+
+@media (max-width: 600px) {
+  .name-faceoff__button {
+    font-size: 1.25rem;
+    padding: 1.25rem 1rem;
+  }
+
+  .name-faceoff__winner-card {
+    padding: 1.5rem;
+  }
+}

--- a/client/src/components/Sidebar/Sidebar.jsx
+++ b/client/src/components/Sidebar/Sidebar.jsx
@@ -22,6 +22,10 @@ const navItems = [
     path: "/chat",
   },
   {
+    id: "faceoff",
+    path: "/faceoff",
+  },
+  {
     id: "store",
     path: "/store",
   },

--- a/client/src/content/appContent.json
+++ b/client/src/content/appContent.json
@@ -9,11 +9,27 @@
       "dashboard": "Dashboard",
       "journals": "Journals",
       "chat": "Chat",
+      "faceoff": "Name Face-Off",
       "store": "Store",
       "cart": "Cart",
       "bookAppointment": "Book Appointment",
       "myAppointments": "My Appointments"
     }
+  },
+  "faceOff": {
+    "title": "Baby Name Face-Off",
+    "description": "Pick your favorite names head-to-head until a single champion remains. Share a seed to replay the same bracket with friends.",
+    "loading": "Loading baby names...",
+    "error": "We couldn't load baby names right now.",
+    "empty": "No names are available for this face-off yet.",
+    "notEnough": "We need at least two names to start a face-off.",
+    "progressPrefix": "Round",
+    "championLabel": "Champion",
+    "challengerLabel": "Challenger",
+    "waiting": "Waiting for challenger...",
+    "winnerTitle": "Your winning name",
+    "playAgain": "Play Again",
+    "resume": "Resuming your latest face-off..."
   },
   "journals": {
     "list": {

--- a/client/src/hooks/useNamesQuery.js
+++ b/client/src/hooks/useNamesQuery.js
@@ -1,0 +1,57 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { http } from "../api/http.js";
+
+const NAMES_QUERY_KEY = "names";
+
+const createQueryString = (params) => {
+  const search = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === "") {
+      return;
+    }
+
+    search.append(key, value);
+  });
+
+  const query = search.toString();
+  return query ? `?${query}` : "";
+};
+
+const createQueryKey = (params) => {
+  if (!params || Object.keys(params).length === 0) {
+    return [NAMES_QUERY_KEY];
+  }
+
+  const sortedEntries = Object.entries(params).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+
+  return [NAMES_QUERY_KEY, Object.fromEntries(sortedEntries)];
+};
+
+const useNamesQuery = (params = {}, options = {}) => {
+  const queryParams = useMemo(() => ({ ...params }), [JSON.stringify(params)]);
+  const queryKey = useMemo(() => createQueryKey(queryParams), [queryParams]);
+  const queryString = useMemo(
+    () => createQueryString(queryParams),
+    [queryParams]
+  );
+
+  return useQuery({
+    queryKey,
+    queryFn: async () => {
+      const response = await http.get(`/api/names${queryString}`);
+      if (!Array.isArray(response)) {
+        return [];
+      }
+
+      return response.filter((value) => typeof value === "string");
+    },
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  });
+};
+
+export default useNamesQuery;

--- a/client/src/pages/FaceOffPage.jsx
+++ b/client/src/pages/FaceOffPage.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import NameFaceOff from "../components/NameFaceOff/NameFaceOff.jsx";
+import content from "../content/appContent.json";
+import "./faceOffPage.styles.scss";
+
+const FaceOffPage = () => (
+  <main className="faceoff-page">
+    <div className="faceoff-page__intro">
+      <h1>{content.faceOff.title}</h1>
+      <p>{content.faceOff.description}</p>
+    </div>
+    <NameFaceOff />
+  </main>
+);
+
+export default FaceOffPage;

--- a/client/src/pages/faceOffPage.styles.scss
+++ b/client/src/pages/faceOffPage.styles.scss
@@ -1,0 +1,32 @@
+.faceoff-page {
+  display: grid;
+  gap: 2rem;
+  padding: 2.5rem 1.5rem 3rem;
+  justify-items: center;
+  color: #f1f3f5;
+}
+
+.faceoff-page__intro {
+  text-align: center;
+  max-width: 640px;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.faceoff-page__intro h1 {
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  font-weight: 700;
+  margin: 0;
+}
+
+.faceoff-page__intro p {
+  margin: 0;
+  color: rgba(241, 243, 245, 0.8);
+  line-height: 1.6;
+}
+
+@media (max-width: 600px) {
+  .faceoff-page {
+    padding: 2rem 1rem 2.5rem;
+  }
+}

--- a/client/src/utils/shuffle.js
+++ b/client/src/utils/shuffle.js
@@ -1,0 +1,48 @@
+const normalizeSeed = (seed) => {
+  if (seed === undefined || seed === null || seed === "") {
+    return null;
+  }
+
+  const text = String(seed);
+  let hash = 0;
+
+  for (let index = 0; index < text.length; index += 1) {
+    hash = (hash << 5) - hash + text.charCodeAt(index);
+    hash |= 0;
+  }
+
+  const normalized = Math.abs(hash);
+  return normalized === 0 ? 1 : normalized;
+};
+
+const createSeededRandom = (seed) => {
+  let value = seed % 2147483647;
+
+  if (value <= 0) {
+    value += 2147483646;
+  }
+
+  return () => {
+    value = (value * 16807) % 2147483647;
+    return (value - 1) / 2147483646;
+  };
+};
+
+const shuffle = (input, seed) => {
+  const source = Array.isArray(input) ? [...input] : [];
+  const normalizedSeed = normalizeSeed(seed);
+  const randomFn = normalizedSeed ? createSeededRandom(normalizedSeed) : Math.random;
+
+  for (let index = source.length - 1; index > 0; index -= 1) {
+    const randomValue = randomFn();
+    const swapIndex = Math.floor(randomValue * (index + 1));
+    const temporary = source[index];
+    source[index] = source[swapIndex];
+    source[swapIndex] = temporary;
+  }
+
+  return source;
+};
+
+export { shuffle };
+export default shuffle;

--- a/server/app.js
+++ b/server/app.js
@@ -12,6 +12,7 @@ const storeRoutes = require("./routes/store");
 const midwifeRoutes = require("./routes/midwives");
 const appointmentRoutes = require("./routes/appointments");
 const journalRoutes = require("./routes/journals");
+const namesRoutes = require("./routes/namesRoutes");
 const errorHandler = require("./middleware/error");
 
 const createApp = (configureApp) => {
@@ -52,6 +53,7 @@ const createApp = (configureApp) => {
   app.use("/api/midwives", midwifeRoutes);
   app.use("/api/appointments", appointmentRoutes);
   app.use("/api/journals", journalRoutes);
+  app.use("/api/names", namesRoutes);
 
   if (typeof configureApp === "function") {
     configureApp(app);

--- a/server/controllers/namesController.js
+++ b/server/controllers/namesController.js
@@ -1,0 +1,51 @@
+const Name = require("../models/Name");
+
+const parseLimit = (value) => {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return 50;
+  }
+  return Math.min(parsed, 200);
+};
+
+const buildQuery = ({ gender, style, q }) => {
+  const query = {};
+
+  if (gender) {
+    query.gender = gender;
+  }
+
+  if (style) {
+    query.style = style;
+  }
+
+  if (q) {
+    query.name = { $regex: q, $options: "i" };
+  }
+
+  return query;
+};
+
+const getNames = async (req, res, next) => {
+  try {
+    const { limit = 50, gender, style, q } = req.query;
+    const query = buildQuery({ gender, style, q });
+    const parsedLimit = parseLimit(limit);
+
+    const names = await Name.find(query)
+      .sort({ name: 1 })
+      .limit(parsedLimit)
+      .select("name")
+      .lean();
+
+    const result = names.map((entry) => entry.name);
+
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+};
+
+module.exports = {
+  getNames,
+};

--- a/server/models/Name.js
+++ b/server/models/Name.js
@@ -1,0 +1,26 @@
+const mongoose = require("mongoose");
+
+const nameSchema = new mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      index: true,
+    },
+    gender: {
+      type: String,
+      trim: true,
+    },
+    style: {
+      type: String,
+      trim: true,
+    },
+  },
+  {
+    timestamps: false,
+    versionKey: false,
+  }
+);
+
+module.exports = mongoose.model("Name", nameSchema);

--- a/server/routes/namesRoutes.js
+++ b/server/routes/namesRoutes.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const { getNames } = require("../controllers/namesController");
+
+const router = express.Router();
+
+router.get("/", getNames);
+
+module.exports = router;

--- a/server/scripts/seedNames.js
+++ b/server/scripts/seedNames.js
@@ -1,0 +1,94 @@
+if (process.env.NODE_ENV !== "production") {
+  require("dotenv").config();
+}
+const mongoose = require("mongoose");
+const connectDB = require("../config/db");
+const Name = require("../models/Name");
+
+const sampleNames = [
+  "Olivia",
+  "Liam",
+  "Amara",
+  "Noah",
+  "Ada",
+  "Kwame",
+  "Sophia",
+  "Mateo",
+  "Zuri",
+  "Aaliyah",
+  "Ethan",
+  "Mia",
+  "Aria",
+  "Kai",
+  "Nia",
+  "Ezra",
+  "Ava",
+  "Imani",
+  "Kofi",
+  "Sienna",
+  "Lucas",
+  "Amelie",
+  "Zara",
+  "Leo",
+  "Maya",
+  "Idris",
+  "Aiden",
+  "Layla",
+  "Omar",
+  "Hana",
+  "Eliana",
+  "Caleb",
+  "Asha",
+  "Jonah",
+  "Esme",
+  "Yusuf",
+  "Isla",
+  "Theo",
+  "Amari",
+  "Amaya",
+  "Jasper",
+  "Naima",
+  "Aaron",
+  "Elsie",
+  "Malik",
+  "Lila",
+  "Nina",
+  "Remi",
+  "Felix",
+  "Zahra",
+];
+
+const seedNames = async () => {
+  try {
+    await connectDB();
+    const existingCount = await Name.countDocuments();
+
+    if (existingCount > 0) {
+      console.log(`Names collection already has ${existingCount} entries. Skipping seed.`);
+      return;
+    }
+
+    const documents = sampleNames.map((name) => ({ name }));
+    await Name.insertMany(documents);
+    console.log(`Inserted ${documents.length} baby names.`);
+  } catch (error) {
+    console.error("Failed to seed names:", error);
+    throw error;
+  } finally {
+    await mongoose.connection.close();
+  }
+};
+
+if (require.main === module) {
+  seedNames()
+    .then(() => {
+      console.log("Name seed completed successfully.");
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error("Name seed failed:", error);
+      process.exit(1);
+    });
+}
+
+module.exports = seedNames;


### PR DESCRIPTION
## Summary
- add a Name mongoose model, controller, route, and seed script to serve GET /api/names with filters
- introduce a reusable React Query hook, seeded shuffle util, and NameFaceOff component/page that persist progress locally
- wire the new face-off route into the app router and navigation content/link for desktop and mobile menus

## Testing
- npm run test:server *(fails: existing integration/unit suites exceed timeouts and missing JWT_SECRET)*
- npm run test:client


------
https://chatgpt.com/codex/tasks/task_e_68d40d4e04308330856b490863114d5e