### PR TITLE
docs: refresh agent playbook and readme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,87 +1,79 @@
-# PregChat Agent Playbook
+# AGENTS
 
-## Purpose & Scope for AI Assistants
-- Agents exist to execute clearly scoped tasks inside this repo. Never broaden the scope or invent extra features.
-- Only touch files explicitly requested by the user or required to keep the build/tests passing. Leave unrelated code, assets, and configuration untouched.
-- When updating generated files (e.g., `package-lock.json`), do so only if the change is a direct result of the requested work.
+## Overview
+- PregChat orchestrates a pregnancy wellness chat that enriches user prompts with profile context, enforces red-flag triage rules, and streams Groq replies while persisting conversations for review.
 
-## Branching, Commits, and PR Discipline
-- Work on feature branches named `feature/<ticket-or-scope>` (e.g., `feature/chat-loading-state`).
-- Commit messages follow `<type>: <imperative summary>` where `type` is one of `feat`, `fix`, `docs`, `refactor`, `test`, or `chore` (example: `docs: update onboarding guide`).
-- Every PR must reference the related issue (if any) in the description and link to screenshots for UI changes.
-- Squash merge only. Do not rewrite history on shared branches.
+## Agents / Modules
+### Chat Session Context (client/src/features/chats/context/ChatSessionContext.jsx)
+- **Name & Role**: ChatSessionProvider — exposes a setter registry so components can register a message-state updater for the active chat session.
+- **Inputs → Outputs**: Accepts a React state setter (`setMessagesSetter(setter)`) and exposes the current setter plus a reset helper.
+- **Core logic & dependencies**: Plain React context built with `useState`, `useCallback`, and `useMemo`; no network calls.
+- **System prompts/instructions**: None.
+- **Memory/session keys**: Stores the setter function in component memory only; no persistence.
+- **Safety rails**: N/A — defers to downstream hooks.
+- **Failure modes & retries**: If `setter` is falsy it clears the registry; otherwise downstream hooks handle mutation errors.
 
-## Code Conventions (Non-Negotiable)
-### Language & Syntax
-- JavaScript only across the stack. No TypeScript, CoffeeScript, or transpiled alternatives.
-- Arrow functions everywhere (React components, hooks, controllers, services, utils). Prefer explicit `const name = () => {}` definitions.
-- Default exports for React components; named exports for hooks, utilities, and constants.
+### Local History Service (client/src/features/messages/hooks/useChatMessages.js & client/src/utils/chatHistory.js)
+- **Name & Role**: useChatMessages — TanStack Query wrapper that keeps an append-only local history for the lightweight ChatBox experience.
+- **Inputs → Outputs**: `appendMessages(message|array)` appends structured messages `{ id, role, content, timestamp }`; `clearMessages(userId?)` purges both localStorage (`pregchat:chats`) and, when a `userId` is provided, calls `DELETE /api/messages/:userId` to clear the server record.
+- **Core logic & dependencies**: Uses React Query `useQuery` + `useMutation`, localStorage helpers, and optional server clear via `fetch(BASE_URL)`.
+- **System prompts/instructions**: None.
+- **Memory/session keys**: Persists under the localStorage key `pregchat:chats` and mirrors payloads returned by `/chat/ask`.
+- **Safety rails**: Falls back to empty arrays on JSON parse errors; server clears require matching `userId` auth on the backend.
+- **Failure modes & retries**: Logs warnings if storage read/write fails; server delete failures are swallowed with `console.warn` so the UI stays responsive.
 
-### Frontend (client/)
-- Framework: React + Vite. Keep components colocated with their styles and tests.
-- Styling: SCSS Modules named `ComponentName.styles.scss`; import them locally (`import styles from "./ComponentName.styles.scss";`). Legacy global styles may exist, but new work must use modules.
-- Routing: `react-router-dom` v6+. Keep route elements lazy-loaded when screens grow.
-- State: Use React Query for server state and colocated custom hooks to wrap query/mutation logic. Redux Toolkit is reserved for UI-only state that must persist across views.
-- Content: Pull copy from `client/src/content/appContent.json` instead of hard-coding strings.
+### Message Delivery Orchestrator (client/src/features/messages/hooks/useSendMessageMutation.js)
+- **Name & Role**: useSendMessageMutation — central mutation that optimistically appends user messages, reconciles assistant replies, and triggers React Query cache updates.
+- **Inputs → Outputs**: Accepts `{ chatId, text, dayData?, stream? }`; outputs assistant payload `{ content|message, triage? }` while tagging messages with `meta.triage` when the server flags urgent content.
+- **Core logic & dependencies**: Uses the shared `http.post` helper, Redux `enqueueToast`, and multiple React Query cache writes (`messagesKeys.list`, `messagesKeys.infinite`, `chatsKeys.detail/list`). Optimistically adds a user bubble, replaces it on success, or rolls back on failure.
+- **System prompts/instructions**: None directly; forwards `dayData` so the backend can expand the system prompt.
+- **Memory/session keys**: Works with chat identifiers from `/chat/conversations/:id`; also saves merged chats back to localStorage via `saveChatsToStorage`.
+- **Safety rails**: Dispatches warning toasts when the backend returns `triage: true`; invalidates caches on settle to ensure reconciliation with the server state.
+- **Failure modes & retries**: If the mutation throws, it removes the optimistic user message and pushes an error toast; HTTP helper retries 5xx responses up to two times.
 
-### Backend (server/)
-- Runtime: Node.js (CommonJS). No ESM modules.
-- Structure: strict MVC under `/server` (`controllers/`, `models/`, `routes/`, `services/`, `utils/`). Add feature folders if needed, but keep routing thin and controllers focused on orchestration.
-- Config: Load environment variables via `.env`. Never default secrets in code.
-- HTTP: Express with wildcard CORS via `cors({ origin: "*", credentials: true })`. Helmet is optional—only add when explicitly required.
-- Persistence: MongoDB via Mongoose models. Reuse existing connection helper `server/config/db.js`.
+### Conversation Service (server/controllers/chatController.js & server/models/Conversation.js)
+- **Name & Role**: ask / getConversations / getConversationMessages — Express handlers that manage persistent chat threads per user.
+- **Inputs → Outputs**: `POST /chat/ask` accepts `{ text, stream? }`, returns `{ content }` or `{ triage, message }`; non-stream calls append paired `{ role, content, timestamp }` messages to the MongoDB `Conversation` document keyed by `userId`.
+- **Core logic & dependencies**: Authenticated routes (`middleware/auth.js`) fetch pregnancy/day context, fan out to `askAya`, and upsert conversations; listing endpoints paginate messages with `page` & `limit` query params and map metadata for the client.
+- **System prompts/instructions**: Pulls day summaries to pass through `askAya` so the system prompt can interpolate pregnancy context.
+- **Memory/session keys**: Mongo `_id` as `chatId`; arrays of message objects stored under `conversation.messages`; `Flag` entries log urgent requests.
+- **Safety rails**: Early `triageCheck` run blocks AI calls for red-flag text and logs `Flag` entries (`reason: "red_flag"`).
+- **Failure modes & retries**: Returns 404 for missing chats or invalid IDs, 500 on DB/AI errors; rate-limited to 20 requests/minute/IP.
 
-## File & Folder Expectations
-- `client/src/components` for shared UI, `client/src/pages` for route views, `client/src/features` for domain-specific hooks/services.
-- `ComponentName.styles.scss` lives beside the component. Tests live beside the unit they validate (e.g., `ComponentName.test.jsx`).
-- Shared constants live in `client/src/constants/` and `server/utils/constants.js` (create if missing rather than scattering magic strings).
-- Asset pipeline: serve generated assets from `server/storage/` through `/static`. Keep CDN-ready artefacts immutable.
+### Aya Assistant Proxy (server/config/ai.js & server/config/prompts.js)
+- **Name & Role**: askAya — wraps Groq chat completions using the Aya persona prompt and optional streaming.
+- **Inputs → Outputs**: Accepts `{ text, region, dayData, stream }`; emits `{ content }`, `{ rawStream }`, or `{ triage, message }` when red-flag detection fires.
+- **Core logic & dependencies**: Fills `SYSTEM_PROMPT_AYA` template with day context, instantiates `Groq` using `GROQ_API_KEY`, and enforces `CHAT_MAX_TOKENS`; appends the disclaimer “Educational only — not a diagnosis.” and optional sign-off (`personaAya.signOff`).
+- **System prompts/instructions**: Persona prompt defines tone, boundaries, triage messaging, and output rules.
+- **Memory/session keys**: No persistent storage; depends on env vars (`GROQ_MODEL`, `AI_SIGN_OFF`).
+- **Safety rails**: Regex `RED_FLAG_PATTERNS` short-circuit to `triageLine(region)`; trims fenced code blocks.
+- **Failure modes & retries**: Throws if `GROQ_API_KEY` is missing; upstream HTTP helper retries 5xx; streaming callers must consume `result.rawStream`.
 
-## React Patterns & UX Rules
-- Each component renders explicit loading and error states when consuming async data. Use skeletons/spinners from shared components where available.
-- Encapsulate data fetching in hooks under `client/src/features/**/hooks`. Hooks should return `{ data, isLoading, isError, error, ... }` from React Query.
-- Optimistic UI updates must roll back on failure (see `useSendMessageMutation` for reference).
-- Keep components lean: UI-only components stay stateless; delegate side-effects to hooks/services.
+### Pregnancy Context Provider (server/models/Pregnancy.js & server/controllers/chatController.js)
+- **Name & Role**: Pregnancy profile + DailyContent lookup — enriches chat requests with gestational day insights.
+- **Inputs → Outputs**: Reads the authenticated user’s `Pregnancy` document, derives `dayIndex`, and loads `DailyContent` (baby update, mom update, tips) before invoking Aya.
+- **Core logic & dependencies**: `Pregnancy.calculateDayIndex()` clamps LMP-based day counts; `DailyContent` stores unique day records with copy and reference URLs.
+- **System prompts/instructions**: Values feed the Aya system prompt placeholders (`{{dayIndex}}`, `{{babyUpdate}}`, etc.).
+- **Memory/session keys**: `Pregnancy.userId` (unique per user) and `DailyContent.day` (0–280) anchor lookups.
+- **Safety rails**: If either profile or content is missing, the chat proceeds without `dayData` and the updates endpoints return 404 guidance.
+- **Failure modes & retries**: Missing profile or content logs warnings; `updateProfile` recalculates day index on LMP/due date updates.
 
-## Testing Policy
-- Backend: Jest + Supertest. Place unit tests in `server/tests/unit` and integration tests in `server/tests/integration`. Run with `npm run test:server` from the repo root.
-- Frontend: Vitest + Testing Library. Store specs beside the component (`*.test.jsx`) or in `client/src/__tests__`. Run with `npm run test:client` from the repo root or `npm test` inside `/client`.
-- End-to-end: Jest E2E config lives at `jest.e2e.config.js`; only touch when explicitly asked.
-- Always update or add tests that cover new behaviours. Never leave failing tests—fix or remove the change.
+### Safety Flag Logger (server/models/Flag.js)
+- **Name & Role**: Flag — persistent record when red-flag conversations occur.
+- **Inputs → Outputs**: Stores `{ userId, text, reason }` when triage trips; later reviewable by ops tooling.
+- **Core logic & dependencies**: Simple Mongoose schema with `timestamps` and index on `{ userId, createdAt }`.
+- **System prompts/instructions**: Triage reason hard-coded as `"red_flag"` in `chatController`.
+- **Memory/session keys**: `Flag` documents keyed by Mongo `_id` with user reference.
+- **Safety rails**: Ensures repeated urgent phrases are captured even if the AI call is skipped.
+- **Failure modes & retries**: Errors bubble to `/chat/ask` handler; no automatic retry.
 
-## Security, Secrets, and Environment Handling
-- `.env` stays uncommitted. Use `.env.example` to document required variables (`PORT`, `MONGO_URI`, `JWT_SECRET`, `GROQ_API_KEY`, `GROQ_MODEL`, `CHAT_MAX_TOKENS`, `AI_SIGN_OFF`, `HUGGING_FACE_API_KEY`, `REGION`, `VITE_API_BASE`).
-- Regenerate tokens/keys before sharing logs. Do not echo secrets in terminal output.
-- `.gitignore` must cover `node_modules/`, `.env*`, build artefacts, and scratch pads (e.g., `notes.txt`).
+## Events & Flows
+- **Start chat**: `useChatsQuery` pulls `/chat/conversations` (falls back to localStorage) → Chat list sorted client-side by `updatedAt` → selecting a chat registers a setter with `ChatSessionProvider`.
+- **Load history (infinite scroll)**: `useInfiniteMessagesQuery` pages `/chat/conversations/:id/messages?page=N&limit=20`, seeding localStorage with `allMessages` from the first page → caches under `messagesKeys.infinite(chatId)`.
+- **Send message**: ChatBox submits text → `useSendMessageMutation.onMutate` adds an optimistic user bubble → server either flags triage (toast + warning bubble) or responds with assistant copy → caches persist via `saveChatsToStorage`.
+- **Receive assistant reply**: Non-stream responses append to caches immediately; streaming callers iterate over `rawStream` chunks and flush partial text, then persist full message on completion.
 
-## React Query Usage Pattern
-1. Define query keys in `client/src/features/<domain>/queryKeys.js`.
-2. Implement fetchers/mutations in dedicated hooks with early returns on invalid params.
-3. Provide loading, empty, and error UI states in consuming components.
-4. Cache writes: update or invalidate queries inside `onSuccess` to keep the UI consistent.
-
-## CI/CD Expectations
-- GitHub Actions pipeline should (at minimum) install dependencies, run `npm run test:server`, run `npm run test:client`, and build the client (`npm --prefix client run build`). Add linting once rules exist.
-- Block merges on failing pipelines. Keep workflows fast (<10 minutes) by caching `node_modules`.
-
-## Pull Request Review Checklist
-- [ ] Scope limited to the issue / request.
-- [ ] All relevant tests (`test:server`, `test:client`, and affected unit specs) pass locally.
-- [ ] Docs updated (README, ADRs, or inline comments) when behaviour changes.
-- [ ] Screenshots or Loom linked for UI tweaks.
-- [ ] Environment variables documented or updated in `.env.example` when new ones are introduced.
-
-## Do & Don't for Agents
-**Do**
-- Answer exactly what the user asked for.
-- Run and report the required commands before delivering work.
-- Use existing patterns (React Query hooks, SCSS modules, CommonJS controllers).
-- Create focused commits that mirror the requested change.
-
-**Don't**
-- Introduce new technologies (TypeScript, Tailwind, alternative state managers).
-- Modify unrelated files, formatting, or dependencies without explicit instruction.
-- Add try/catch around imports or convert modules to default exports unless required by the task.
-- Fabricate endpoints, scripts, or features that do not exist in the codebase.
-
-Follow this playbook to keep PregChat consistent, testable, and production-ready.
+## Extensibility
+- To add a new tool/agent in the assistant response, extend `SYSTEM_PROMPT_AYA` (server/config/prompts.js) and handle payload flags in `askAya`; update `mapChatDetailFromApi` and `appendToMessagesCache` if the response adds new `meta` fields.
+- To attach message metadata (e.g., sources), extend the message shape in `Conversation` schema and update client mappers in `client/src/features/chats/mappers.js` plus cache writers in `useSendMessageMutation`.
+- New safety checks belong in `triageCheck` (server/config/ai.js); mirror them on the client if the UI needs to react optimistically.

--- a/README.md
+++ b/README.md
@@ -1,307 +1,165 @@
 # PregChat
+Pregnancy wellness companion that pairs Groq-powered chat guidance with scheduling, journaling, and commerce workflows in a MERN stack.
 
-[![Node.js](https://img.shields.io/badge/Node.js-20.x-339933?logo=node.js&logoColor=white)](#) [![React](https://img.shields.io/badge/React-18-61dafb?logo=react&logoColor=black)](#) [![Vite](https://img.shields.io/badge/Vite-5-646cff?logo=vite&logoColor=white)](#) [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](LICENSE)
+## Key Features
+- **Aya chat assistant** – Authenticated users chat with Aya, who enriches prompts with pregnancy day data and enforces red-flag triage before persisting messages. (/client/src/components/ChatBox/ChatBox.jsx, /server/controllers/chatController.js, /server/config/ai.js)
+- **Daily insights & imagery** – Updates endpoints serve gestational tips, and the baby image service generates or reuses day-specific renders backed by Hugging Face. (/server/controllers/updatesController.js, /server/controllers/babyImageController.js)
+- **Midwife scheduling** – Availability is computed in London time, with conflict checking and CRUD for appointments. (/server/controllers/appointmentController.js, /server/utils/slots.js)
+- **Personal journals** – Users manage private journal entries with ownership checks and validation. (/server/controllers/journalController.js)
+- **Storefront & names explorer** – Mongo-backed catalog endpoints feed the store UI and curated baby name suggestions. (/server/controllers/storeController.js, /server/controllers/namesController.js)
 
-PregChat is a MERN-based pregnancy wellness companion that combines Groq-powered chat guidance, daily fetal development updates, journaling, commerce, and midwife appointment scheduling in one secure experience.
+## Tech Stack
+- **Frontend**: React 18, React Router, React Query, Redux Toolkit, SCSS modules, Vite dev server. (/client/src/main.jsx, /client/package.json)
+- **Backend**: Express, Mongoose, Groq SDK, express-rate-limit, JWT auth via middleware. (/server/app.js, /server/controllers/authController.js)
+- **Data**: MongoDB models for conversations, pregnancy profiles, daily content, appointments, journals, products, and flags. (/server/models/Conversation.js, /server/models/Pregnancy.js)
 
-## 📸 Screenshots & Media
-Add UI captures under `docs/` (for example, `docs/dashboard.png`) and embed them here:
-
-```markdown
-![Dashboard](docs/dashboard.png)
+## Architecture Overview
+```
+React client (React Query, Redux)
+        │  httpRequest (fetch + retries)
+        ▼
+Express API (app.js → controllers)
+        │                      │
+        │                      ├─ Groq LLM (askAya)
+        ▼                      └─ HuggingFace image generation
+MongoDB (Mongoose models)
 ```
 
-## ✨ Features
-- **AI chat coach** – Authenticated users converse with Aya, a Groq-backed assistant that enriches prompts with pregnancy context and applies safety guardrails.【F:client/src/components/ChatBox/ChatBox.jsx†L27-L215】【F:server/controllers/chatController.js†L7-L91】
-- **Daily pregnancy insights** – React Query hooks fetch day-specific updates, baby imagery, and profile-driven content from Express endpoints.【F:client/src/features/pregnancy/hooks/usePregnancy.js†L1-L64】【F:server/routes/updatesRoutes.js†L1-L18】
-- **Midwife marketplace** – Browse midwives, check availability in London time, and create or cancel appointments with conflict detection.【F:client/src/pages/AppointmentMidwife.jsx†L1-L270】【F:server/controllers/appointmentController.js†L1-L200】
-- **Personal journals** – CRUD journals scoped to the authenticated user with server-side validation and ownership checks.【F:client/src/pages/JournalDetail.jsx†L1-L131】【F:server/controllers/journalController.js†L1-L200】
-- **Pregnancy store** – React storefront backed by MongoDB items with detail pages and cart context.【F:client/src/pages/Store/Store.jsx†L1-L143】【F:server/controllers/storeController.js†L1-L36】
-- **Profile onboarding** – Guided onboarding flow persists pregnancy profile and household details via secure APIs.【F:client/src/pages/Onboarding/Onboarding.jsx†L1-L209】【F:server/routes/onboarding.routes.js†L1-L12】
+### Core Data Models
+| Model | Key Fields |
+| --- | --- |
+| Conversation | `userId`, `messages[{ role, content, timestamp }]`, timestamps. (/server/models/Conversation.js)
+| Pregnancy | `userId`, `lmpDate`, `dueDate`, `dayIndex` with helper methods. (/server/models/Pregnancy.js)
+| DailyContent | `day`, `babyUpdate`, `momUpdate`, `tips`, `assets`, `references`. (/server/models/DailyContent.js)
+| Flag | `userId`, `text`, `reason` enum for red-flag logging. (/server/models/Flag.js)
+| Appointment | `userId`, `midwifeId`, `start`, `end`, `status`. (/server/models/Appointment.js)
+| Journal | `userId`, `title`, `content`, optional `date`. (/server/models/Journal.js)
+| Item/Product | Catalog fields: `name`/`title`, `price`, `stock`/`inStock`, `slug`. (/server/models/Item.js, /server/models/product.model.js)
 
-## 🧰 Tech Stack
-### Frontend
-- React 18 with Vite toolchain and JSX arrow-function components.【F:client/src/App.jsx†L1-L109】
-- React Router v6 for routing and protected routes.【F:client/src/App.jsx†L40-L109】
-- React Query + custom hooks for server state and caching.【F:client/src/features/chats/hooks/useChatsQuery.js†L1-L39】
-- Redux Toolkit slice for auth token persistence and UI state.【F:client/src/store/ui/uiSlice.js†L1-L121】
-- SCSS Modules for component-scoped styling (legacy global styles will be migrated).【F:client/src/pages/AppointmentBrowse.styles.module.scss†L1-L20】
-
-### Backend
-- Express server with CommonJS modules and wildcard CORS.【F:server/app.js†L1-L49】【F:server/server.js†L1-L25】
-- MongoDB via Mongoose models for users, conversations, content, journals, midwives, and appointments.【F:server/models/User.js†L1-L82】【F:server/models/Appointment.js†L1-L93】
-- Groq SDK for LLM chat completion and huggingface image service for baby renders.【F:server/config/ai.js†L1-L110】【F:server/services/hfGenerate.js†L1-L33】
-- Rate limiting, JWT auth, and centralized error handling middleware.【F:server/app.js†L19-L47】【F:server/middleware/auth.js†L1-L26】【F:server/middleware/error.js†L1-L30】
-
-## 🏗️ Architecture Overview
+## Folder Structure
 ```
-pregchat/
-├── client/
-│   ├── src/
-│   │   ├── api/
-│   │   ├── components/
-│   │   ├── content/
-│   │   ├── features/
-│   │   ├── pages/
-│   │   ├── services/
-│   │   ├── store/
-│   │   └── utils/
-│   ├── package.json
-│   └── vite.config.js
-├── server/
-│   ├── config/
-│   ├── controllers/
-│   ├── middleware/
-│   ├── models/
-│   ├── routes/
-│   ├── services/
-│   ├── tests/
+.
+├── client/                # React app (Vite, SCSS modules, features/* hooks)
+│   ├── src/api            # http helpers
+│   ├── src/features       # Domain hooks, query keys, storage helpers
+│   ├── src/pages          # Route-level views
+│   ├── src/store          # Redux Toolkit slices
+│   └── package.json
+├── server/                # Express API (MVC)
+│   ├── controllers        # Route handlers
+│   ├── models             # Mongoose schemas
+│   ├── routes             # Express routers
+│   ├── services           # Baby image generator & external calls
 │   └── server.js
-├── package.json
-├── .env.example
-└── README.md
+├── tests/                 # E2E/Jest entry points
+├── package.json           # Root scripts (concurrently runs client/server)
+├── Procfile               # Deploys Express via `npm start`
+└── .env.example           # Documented environment variables
 ```
 
-### Data Flow
-1. The Vite client reads copy from `client/src/content/appContent.json`, manages auth state via Redux, and fetches resources with React Query.
-2. API calls route through `client/src/api/http.js`, which attaches bearer tokens and retries transient failures before hitting Express.【F:client/src/api/http.js†L1-L87】
-3. Express routes authenticate requests (where required), delegate to controllers, and persist data with Mongoose models.【F:server/routes/chatRoutes.js†L1-L24】【F:server/controllers/chatController.js†L7-L91】
-4. Responses hydrate React Query caches to keep chat, appointments, store, and journals consistent across views.【F:client/src/features/messages/hooks/useSendMessageMutation.js†L249-L337】
+## Environment Variables
+| Name | Description |
+| --- | --- |
+| `PORT` | Express port (defaults to 5000 if unset). (/server/index.js, /.env.example)
+| `ALLOWED_ORIGINS` | Comma-separated CORS allowlist. (/server/config/cors.js)
+| `MONGO_URI` | MongoDB connection string. (/server/config/db.js)
+| `JWT_SECRET` | Signing key for auth tokens. (/server/utils/token.js)
+| `GROQ_API_KEY` / `GROQ_MODEL` | Credentials for Groq chat completions. (/server/config/ai.js)
+| `CHAT_MAX_TOKENS` | Token ceiling for Aya replies. (/server/config/ai.js)
+| `AI_SIGN_OFF` | Toggles persona sign-off injection. (/server/config/ai.js, /server/config/persona.js)
+| `HUGGING_FACE_API_KEY` | Auth for baby image generation. (/server/services/hfGenerate.js)
+| `REGION` | Default locale for triage messaging. (/.env.example)
+| `VITE_API_BASE` | Client base URL for API requests. (/client/src/constants/baseUrl.js)
 
-## ⚡ Quick Start
-### 1. Prerequisites
-- Node.js 20.x (see `package.json` engines).【F:package.json†L37-L39】
-- npm 9+ (ships with Node 20).
-- Running MongoDB instance (local or remote).
+## Setup & Installation
+1. Clone the repo and install root dependencies:
+   ```bash
+   git clone https://github.com/kofiarhin/pregchat.git
+   cd pregchat
+   npm install
+   ```
+2. Install backend packages:
+   ```bash
+   cd server
+   npm install
+   cd ..
+   ```
+3. Install frontend packages:
+   ```bash
+   cd client
+   npm install
+   cd ..
+   ```
+4. Copy `.env.example` to `.env` and configure the variables above (server listens on 5001 in the example while Vite runs on 5000).
+5. Ensure MongoDB is running and Groq/Hugging Face keys are provisioned if you need AI responses or image generation.
 
-### 2. Clone & Install
-```bash
-git clone https://github.com/kofiarhin/pregchat.git
-cd pregchat
-
-# root dependencies (Express utilities, shared tooling)
-npm install
-
-# backend dependencies
-cd server
-npm install
-cd ..
-
-# frontend dependencies
-cd client
-npm install
-cd ..
-```
-
-### 3. Environment Variables
-Copy `.env.example` to `.env` and adjust values. Only configure keys that the code consumes.
-
-```env
-# server
-PORT=5001
-MONGO_URI=mongodb://localhost:27017/pregchat
-JWT_SECRET=change_me
-GROQ_API_KEY=change_me
-GROQ_MODEL=llama-3.1-8b-instant
-CHAT_MAX_TOKENS=1024
-AI_SIGN_OFF=true
-HUGGING_FACE_API_KEY=
-REGION=UK
-
-# client
-VITE_API_BASE=http://localhost:5001
-```
-
-### 4. Useful Scripts
-| Location | Command | Description |
+## Running & Scripts
+| Location | Command | Purpose |
 | --- | --- | --- |
-| root | `npm run dev` | Start server (nodemon) and client (Vite on port 5000) concurrently.【F:package.json†L7-L13】 |
-| root | `npm run start:server` | Run the Express API with nodemon for local development.【F:package.json†L9-L10】 |
-| root | `npm run start:client` | Run the Vite dev server on port 5000.【F:package.json†L10-L11】 |
-| root | `npm start` | Launch the Express server in production mode (no client).【F:package.json†L7-L8】 |
-| root | `npm run test:server` | Execute Jest + Supertest against `/server`.【F:package.json†L11-L12】 |
-| root | `npm run test:client` | Execute Vitest against `/client`.【F:package.json†L12-L13】 |
-| root | `npm run test:unit` / `npm run test:integration` | Targeted backend Jest suites.【F:package.json†L13-L15】 |
-| root | `npm run e2e` | Run end-to-end Jest config (`jest.e2e.config.js`).【F:package.json†L15-L16】 |
-| client | `npm run dev` | Start Vite dev server (port 5000).【F:client/package.json†L6-L9】 |
-| client | `npm run build` | Create production bundle in `client/dist`.【F:client/package.json†L6-L10】 |
-| client | `npm run preview` | Preview the built bundle locally.【F:client/package.json†L6-L10】 |
-| client | `npm test` | Run Vitest in watch or CI mode.【F:client/package.json†L6-L10】 |
-| server | `npm run dev` | Nodemon hot-reload for the Express server.【F:server/package.json†L7-L10】 |
-| server | `npm test` | Run server Jest suite from `/server`.【F:server/package.json†L7-L10】 |
+| root | `npm run dev` | Run Express (`server/index.js`) and Vite concurrently via `concurrently`. (/package.json)
+| root | `npm start` | Launch Express in production mode (`server/server.js`). (/package.json)
+| root | `npm run test:server` / `npm run test:client` | Execute Jest (server) and Vitest (client). (/package.json)
+| root | `npm run test:unit` / `npm run test:integration` | Focused backend Jest configs. (/package.json)
+| root | `npm run e2e` | Run Jest E2E suite (`jest.e2e.config.js`). (/package.json)
+| client | `npm run dev` / `npm run build` / `npm run preview` | Vite dev/build/preview commands (default port 5000). (/client/package.json)
+| client | `npm test` | Run Vitest for the React app. (/client/package.json)
+| server | `npm run dev` / `npm start` | Nodemon dev server or plain Node entry. (/server/package.json)
+| server | `npm test` | Run Jest within the server workspace. (/server/package.json)
 
-### 5. Run Locally
-```bash
-# from repo root with .env configured
-npm run dev
-```
-The client runs on `http://localhost:5000` and proxies API calls to `http://localhost:5001` (configure `PORT` and `VITE_API_BASE` if you choose different ports).
+## API Reference
+| Method | Path | Controller | Description |
+| --- | --- | --- | --- |
+| POST | `/auth/register` | authController.register | Create a user, hash password, return JWT. (/server/routes/authRoutes.js)
+| POST | `/auth/login` | authController.login | Authenticate and issue JWT. (/server/routes/authRoutes.js)
+| GET | `/auth/me` | authController.me | Return authenticated profile. (/server/routes/authRoutes.js)
+| GET | `/chat/conversations` | chatController.getConversations | List user chats sorted by `updatedAt`. (/server/routes/chatRoutes.js)
+| GET | `/chat/conversations/:conversationId/messages` | chatController.getConversationMessages | Paginate chat history with `page`/`limit` query params. (/server/routes/chatRoutes.js)
+| POST | `/chat/ask` | chatController.ask | Run triage + Aya response, optionally stream. (/server/routes/chatRoutes.js)
+| GET | `/updates/today` | updatesController.getToday | Fetch today’s pregnancy summary for the user. (/server/routes/updatesRoutes.js)
+| GET | `/updates/:day` | updatesController.getDay | Fetch specific day content. (/server/routes/updatesRoutes.js)
+| PUT | `/updates/profile` | updatesController.updateProfile | Upsert pregnancy profile (LMP or due date). (/server/routes/updatesRoutes.js)
+| POST | `/admin/content` | adminController.upsertContent | Bulk upsert DailyContent entries. (/server/routes/adminRoutes.js)
+| DELETE | `/api/messages/:userId` | messageController.deleteMessagesForUser | Clear stored conversation for a user. (/server/routes/messages.js)
+| GET | `/api/store/` | storeController.getStoreItems | List store items. (/server/routes/store.js)
+| GET | `/api/store/:id` | storeController.getStoreItemById | Fetch a single store item. (/server/routes/store.js)
+| POST | `/api/store/` | storeController.createStoreItem | Create a store item (no auth guard). (/server/routes/store.js)
+| GET | `/api/midwives/` | midwifeController.getMidwives | List all midwives. (/server/routes/midwives.js)
+| GET | `/api/midwives/:id` | midwifeController.getMidwifeById | Fetch midwife by id. (/server/routes/midwives.js)
+| GET | `/api/appointments/my` | appointmentController.getMyAppointments | List appointments for the requester. (/server/routes/appointments.js)
+| POST | `/api/appointments/availability` | appointmentController.getAvailability | Compute free slots for a midwife/date range. (/server/routes/appointments.js)
+| POST | `/api/appointments/` | appointmentController.createAppointment | Book an appointment slot. (/server/routes/appointments.js)
+| DELETE | `/api/appointments/:id` | appointmentController.cancelAppointment | Cancel an appointment. (/server/routes/appointments.js)
+| GET | `/api/journals/` | journalController.getJournals | List journals for a user id. (/server/routes/journals.js)
+| GET | `/api/journals/:id` | journalController.getJournalById | Retrieve a single journal. (/server/routes/journals.js)
+| POST | `/api/journals/` | journalController.createJournal | Create a journal entry. (/server/routes/journals.js)
+| PUT | `/api/journals/:id` | journalController.updateJournal | Update a journal entry. (/server/routes/journals.js)
+| DELETE | `/api/journals/:id` | journalController.deleteJournal | Delete a journal entry. (/server/routes/journals.js)
+| GET | `/api/names/` | namesController.getNames | Return curated baby names sample. (/server/routes/namesRoutes.js)
+| GET | `/api/baby-image/today` | babyImageController.getTodayBabyImage | Generate or fetch cached daily baby image. (/server/routes/babyImageRoutes.js)
+| GET | `/api/onboarding/me` | onboarding.controller.getMyDetails | Fetch onboarding details for the user. (/server/routes/onboarding.routes.js)
+| POST | `/api/onboarding/me` | onboarding.controller.upsertMyDetails | Save onboarding questionnaire answers. (/server/routes/onboarding.routes.js)
+| PATCH | `/api/profile/:id` | profile.controller.updateProfile | Update profile document fields. (/server/routes/profile.routes.js)
 
-## ✅ Testing
-- `npm run test:client` – runs Vitest against the React app from the repository root.【F:package.json†L12-L13】
-- `npm run test:server` – runs Jest + Supertest suites under `server/tests`.【F:package.json†L11-L12】
-- `npm run e2e` – executes the full-stack Jest end-to-end scenarios defined at the repo root.【F:package.json†L15-L16】
+## Frontend Notes
+- **HTTP layer**: `client/src/api/http.js` wraps `fetch` with retries, bearer token injection via Redux selectors, and JSON parsing fallbacks.
+- **React Query keys**: `chatsKeys` (`client/src/features/chats/queryKeys.js`), `pregnancyKeys` (`client/src/features/pregnancy/queryKeys.js`), `authKeys` (`client/src/features/auth/queryKeys.js`), and local `chatMessageKeys` (`client/src/features/messages/queryKeys.js`) standardise cache namespaces.
+- **Chat flows**: `useSendMessageMutation` handles optimistic updates, triage toasts, and cache invalidation; `useChatsQuery`/`useMessagesQuery` back up to localStorage for offline resilience. (/client/src/features/messages/hooks/useSendMessageMutation.js)
+- **Global state**: `uiSlice` stores auth tokens, toasts, and modal state; `store/store.js` exposes typed hooks. (/client/src/store/ui/uiSlice.js)
+- **Context providers**: `ChatSessionContext`, `CartContext`, and `BookingContext` wrap the app in `main.jsx` for shared UI state. (/client/src/main.jsx)
+- **Styling**: Route-level screens use SCSS modules (e.g., `AppointmentBrowse.styles.module.scss`); legacy components like `ChatBox` import global SCSS while migration is in progress. (/client/src/pages/AppointmentBrowse.styles.module.scss, /client/src/components/ChatBox/chatBox.styles.scss)
 
-## 🏗️ Build & Production
-- Frontend: `npm --prefix client run build` outputs static assets to `client/dist`. Deploy that folder to Vercel or any static host.【F:client/package.json†L6-L10】
-- Backend: `npm start` (root) or `npm --prefix server start` boots Express after environment setup. Ensure MongoDB and Groq/HuggingFace keys are configured.【F:package.json†L7-L8】【F:server/server.js†L1-L25】
+## Testing
+- Server: `npm run test:server` runs Jest with Supertest (configs in `server/jest.*.config.js`).
+- Client: `npm run test:client` triggers Vitest (`client/vitest.config.*` via package.json script).
+- No additional automated linting is configured.
 
-## 🚀 Deployment Playbook
-### Vercel (Frontend)
-1. Import the repo into Vercel and select the `client` directory as the project root.
-2. Set build command to `npm run build` and output directory to `dist`.
-3. Provide environment variables prefixed with `VITE_` (e.g., `VITE_API_BASE=https://your-api.onrender.com`).
-4. Trigger a deployment; Vercel serves the generated static bundle.
+## Deployment
+- Procfile exposes `web: npm start`; additional deployment automation is not yet documented. (/Procfile)
 
-### Render or Heroku (Backend)
-1. Provision a Node service and connect to this repo.
-2. Install dependencies (`npm install && npm --prefix server install` in build steps or use a monorepo script).
-3. Set environment variables (`PORT`, `MONGO_URI`, `JWT_SECRET`, `GROQ_API_KEY`, etc.).
-4. Use `npm start` as the start command (Heroku will pick up `Procfile` if configured).【F:Procfile†L1-L1】
-5. Ensure MongoDB and any AI providers are reachable from the platform.
+## Security & Compliance
+- Conversations require JWT auth (`Authorization: Bearer <token>`), and requests rate-limit at 20 chat calls per minute. (/server/middleware/auth.js, /server/routes/chatRoutes.js)
+- Aya replies always end with “Educational only — not a diagnosis.” and trigger urgent-care messaging on red-flag inputs; all guidance is educational, not medical advice. (/server/config/prompts.js, /server/config/ai.js)
+- Red-flag messages are persisted in the `Flag` collection for follow-up, but no PHI storage beyond user-provided details exists. (/server/models/Flag.js)
 
-## 🔌 API Reference
-Replace `<API_BASE>` with your server origin (e.g., `http://localhost:5001`). Authenticated routes require `Authorization: Bearer <token>`.
-
-### Auth
-```bash
-curl -X POST "<API_BASE>/auth/register" \
-  -H "Content-Type: application/json" \
-  -d '{"name":"Test User","email":"test@example.com","password":"secret123","region":"UK"}'
-
-curl -X POST "<API_BASE>/auth/login" \
-  -H "Content-Type: application/json" \
-  -d '{"email":"test@example.com","password":"secret123"}'
-
-curl -X GET "<API_BASE>/auth/me" \
-  -H "Authorization: Bearer <token>"
-```
-
-### Chat
-```bash
-curl -X GET "<API_BASE>/chat/conversations" \
-  -H "Authorization: Bearer <token>"
-
-curl -X POST "<API_BASE>/chat/ask" \
-  -H "Authorization: Bearer <token>" \
-  -H "Content-Type: application/json" \
-  -d '{"conversationId":"<id>","message":"How is baby doing today?"}'
-```
-
-### Pregnancy Updates & Profile
-```bash
-curl -X GET "<API_BASE>/updates/today" \
-  -H "Authorization: Bearer <token>"
-
-curl -X GET "<API_BASE>/updates/100" \
-  -H "Authorization: Bearer <token>"
-
-curl -X PUT "<API_BASE>/updates/profile" \
-  -H "Authorization: Bearer <token>" \
-  -H "Content-Type: application/json" \
-  -d '{"lmpDate":"2024-01-01","dueDate":"2024-10-07","weeks":10,"days":3}'
-```
-
-### Admin Content
-```bash
-curl -X POST "<API_BASE>/admin/content" \
-  -H "Authorization: Bearer <token>" \
-  -H "Content-Type: application/json" \
-  -d '{"day":100,"babyUpdate":"...","momUpdate":"..."}'
-```
-
-### Onboarding
-```bash
-curl -X GET "<API_BASE>/api/onboarding/me" \
-  -H "Authorization: Bearer <token>"
-
-curl -X POST "<API_BASE>/api/onboarding/me" \
-  -H "Authorization: Bearer <token>" \
-  -H "Content-Type: application/json" \
-  -d '{"occupation":"Designer","supportCircle":["Partner"]}'
-```
-
-### Chat History
-```bash
-curl -X DELETE "<API_BASE>/api/messages/<userId>" \
-  -H "Authorization: Bearer <token>"
-```
-
-### Store
-```bash
-curl -X GET "<API_BASE>/api/store"
-
-curl -X GET "<API_BASE>/api/store/<itemId>"
-
-curl -X POST "<API_BASE>/api/store" \
-  -H "Content-Type: application/json" \
-  -d '{"name":"Prenatal Vitamins","price":19.99,"stock":10}'
-```
-
-### Midwives & Appointments
-```bash
-curl -X GET "<API_BASE>/api/midwives"
-
-curl -X GET "<API_BASE>/api/midwives/<midwifeId>"
-
-curl -X POST "<API_BASE>/api/appointments/availability" \
-  -H "Content-Type: application/json" \
-  -d '{"midwifeId":"<midwifeId>","fromISO":"2024-07-01T09:00:00.000Z","toISO":"2024-07-02T09:00:00.000Z"}'
-
-curl -X GET "<API_BASE>/api/appointments/my" \
-  -H "Authorization: Bearer <token>"
-
-curl -X POST "<API_BASE>/api/appointments" \
-  -H "Content-Type: application/json" \
-  -d '{"userId":"<userId>","midwifeId":"<midwifeId>","startISO":"2024-07-01T10:00:00.000Z"}'
-
-curl -X DELETE "<API_BASE>/api/appointments/<appointmentId>"
-```
-
-### Journals
-```bash
-curl -X GET "<API_BASE>/api/journals?userId=<userId>"
-
-curl -X GET "<API_BASE>/api/journals/<journalId>?userId=<userId>"
-
-curl -X POST "<API_BASE>/api/journals" \
-  -H "Content-Type: application/json" \
-  -d '{"userId":"<userId>","title":"Entry","content":"Feeling great!"}'
-
-curl -X PUT "<API_BASE>/api/journals/<journalId>" \
-  -H "Content-Type: application/json" \
-  -d '{"userId":"<userId>","title":"Updated","content":"Still feeling great"}'
-
-curl -X DELETE "<API_BASE>/api/journals/<journalId>?userId=<userId>"
-```
-
-### Names & Baby Image
-```bash
-curl -X GET "<API_BASE>/api/names"
-
-curl -X GET "<API_BASE>/api/baby-image/today" \
-  -H "Authorization: Bearer <token>"
-```
-
-### Health
-```bash
-curl -X GET "<API_BASE>/health"
-```
-
-## 🤝 Contributing
-1. Create a feature branch following `feature/<scope>` naming.
-2. Adhere to the coding standards in [AGENTS.md](AGENTS.md) (JavaScript only, arrow functions, SCSS modules, CommonJS backend).
-3. Keep commits scoped and use the `<type>: <summary>` convention.
-4. Run `npm run test:client` and `npm run test:server` before opening a PR.
-5. Submit a focused PR with context, screenshots (for UI), and updated docs where needed.
-
-## 📄 License
-This project is released under the ISC License (see `package.json`).【F:package.json†L3-L35】
-
-## 🛠️ Troubleshooting
-- **Port conflicts** – Set `PORT` to `5001` (or another open port) in `.env` so the API and Vite dev server do not clash.【F:.env.example†L1-L13】【F:package.json†L9-L11】
-- **CORS errors** – Ensure the frontend points to the correct API origin via `VITE_API_BASE`; the server defaults to wildcard CORS but incorrect origins will still fail auth.【F:client/src/constants/baseUrl.js†L1-L4】【F:server/app.js†L1-L28】
-- **Environment not loading** – Confirm `.env` is at the repo root and that `dotenv` loads before server start (see `server/server.js`). Missing `MONGO_URI` or `GROQ_API_KEY` will crash startup.【F:server/server.js†L1-L25】【F:server/config/db.js†L1-L17】
-- **MongoDB connection issues** – Verify the database URI and that MongoDB is reachable; connection failures exit the process with a descriptive error.【F:server/config/db.js†L1-L17】
-
-Run into something else? Open an issue with logs and reproduction steps so we can harden PregChat.
+## License
+Distributed under the ISC License. (/package.json)


### PR DESCRIPTION
## Summary
- document chat-related agents, safety rails, and data flows in `AGENTS.md`
- rewrite `README.md` with production-ready setup, API, and frontend notes grounded in repo files

## Testing
- not run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d5deb1fc088330b5ef308a6e5d32aa