### PR TITLE
Add voice capture and playback support to chat UI

### DIFF
--- a/client/src/components/ChatInput.jsx
+++ b/client/src/components/ChatInput.jsx
@@ -1,0 +1,91 @@
+import React, { useCallback, useRef, useState } from "react";
+import { FiSend } from "react-icons/fi";
+import VoiceControls from "./VoiceControls.jsx";
+import "./chatInput.styles.scss";
+
+const ChatInput = ({
+  onSend,
+  placeholder = "Ask Aya about your pregnancy...",
+  isSending = false,
+  autoFocus = true,
+}) => {
+  const [value, setValue] = useState("");
+  const inputRef = useRef(null);
+
+  const handleSend = useCallback(
+    async (text) => {
+      const message = typeof text === "string" ? text.trim() : "";
+
+      if (!message || typeof onSend !== "function" || isSending) {
+        return;
+      }
+
+      await onSend(message);
+    },
+    [isSending, onSend],
+  );
+
+  const resetInput = useCallback(() => {
+    setValue("");
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const message = value.trim();
+
+    if (!message || isSending) {
+      return;
+    }
+
+    await handleSend(message);
+    resetInput();
+  };
+
+  const handleVoiceSend = useCallback(
+    async (text) => {
+      const clean = (text || "").trim();
+
+      if (!clean) {
+        return;
+      }
+
+      await handleSend(clean);
+      resetInput();
+    },
+    [handleSend, resetInput],
+  );
+
+  return (
+    <div className="chatInput">
+      <form className="chatInput__form" onSubmit={handleSubmit}>
+        <div className="chatInput__field">
+          <input
+            ref={inputRef}
+            className="chatInput__input"
+            type="text"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            placeholder={placeholder}
+            disabled={isSending}
+            autoFocus={autoFocus}
+            aria-label="Type your message"
+          />
+          <button
+            className="chatInput__send"
+            type="submit"
+            aria-label="Send message"
+            title="Send message"
+            disabled={!value.trim() || isSending}
+          >
+            <FiSend aria-hidden="true" />
+          </button>
+        </div>
+      </form>
+
+      <VoiceControls onSend={handleVoiceSend} />
+    </div>
+  );
+};
+
+export default ChatInput;

--- a/client/src/components/ChatWindow.jsx
+++ b/client/src/components/ChatWindow.jsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useRef } from "react";
+import useVoice from "../hooks/useVoice.js";
+import "./chatWindow.styles.scss";
+
+const formatTime = (value) => {
+  try {
+    return new Date(value).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch (error) {
+    return "";
+  }
+};
+
+const ChatWindow = ({ messages = [], isSending = false }) => {
+  const scrollAnchorRef = useRef(null);
+  const lastSpokenRef = useRef(null);
+  const { supported, speak, cancelSpeech } = useVoice();
+
+  useEffect(() => {
+    scrollAnchorRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages.length, isSending]);
+
+  useEffect(() => {
+    if (!supported.tts) {
+      return undefined;
+    }
+
+    const latestAssistant = [...messages]
+      .reverse()
+      .find((message) => message?.role === "assistant" && message?.content);
+
+    if (!latestAssistant) {
+      return undefined;
+    }
+
+    const key = latestAssistant.id || latestAssistant.timestamp || latestAssistant.content;
+
+    if (lastSpokenRef.current === key) {
+      return undefined;
+    }
+
+    lastSpokenRef.current = key;
+
+    speak(latestAssistant.content, {
+      rate: 0.96,
+      pitch: 1,
+      volume: 1,
+    });
+
+    return () => {
+      cancelSpeech();
+    };
+  }, [messages, speak, cancelSpeech, supported.tts]);
+
+  useEffect(() => {
+    if (!messages.length) {
+      lastSpokenRef.current = null;
+    }
+  }, [messages.length]);
+
+  useEffect(() => () => {
+    cancelSpeech();
+  }, [cancelSpeech]);
+
+  const renderMessage = (entry, index) => {
+    const tone = entry?.meta?.triage ? "triage" : entry?.role;
+    const key = entry?.id || entry?.timestamp || index;
+
+    return (
+      <div key={key} className={`bubble bubble--${tone ?? "assistant"}`}>
+        <div className="body">
+          {entry?.meta?.triage && <div className="flag">Important</div>}
+          <p>{entry?.content}</p>
+        </div>
+        <time className="time">{formatTime(entry?.timestamp)}</time>
+      </div>
+    );
+  };
+
+  return (
+    <main className="messages">
+      {messages.map(renderMessage)}
+
+      {isSending && (
+        <div className="bubble bubble--assistant">
+          <div className="body">
+            <div className="typing">
+              <span />
+              <span />
+              <span />
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div ref={scrollAnchorRef} />
+    </main>
+  );
+};
+
+export default ChatWindow;

--- a/client/src/components/VoiceControls.jsx
+++ b/client/src/components/VoiceControls.jsx
@@ -1,0 +1,134 @@
+import React, { useMemo } from "react";
+import { FiMic, FiMicOff, FiPlay, FiSquare } from "react-icons/fi";
+import useVoice from "../hooks/useVoice.js";
+import styles from "./voiceControls.styles.scss?inline";
+
+const VoiceControls = ({ onSend }) => {
+  const {
+    supported,
+    isListening,
+    transcript,
+    interim,
+    start,
+    stop,
+    speak,
+    cancelSpeech,
+    setTranscript,
+  } = useVoice();
+
+  const canUseStt = supported.stt;
+  const canUseTts = supported.tts;
+
+  const combinedTranscript = useMemo(() => {
+    if (transcript && interim) {
+      return `${transcript} ${interim}`.trim();
+    }
+
+    return (transcript || interim || "").trim();
+  }, [transcript, interim]);
+
+  const handleToggleRecording = () => {
+    if (!canUseStt) {
+      return;
+    }
+
+    if (isListening) {
+      stop();
+      return;
+    }
+
+    start();
+  };
+
+  const handleUseText = () => {
+    const text = combinedTranscript;
+
+    if (!text) {
+      return;
+    }
+
+    if (typeof onSend === "function") {
+      onSend(text);
+    }
+
+    setTranscript("");
+    stop();
+  };
+
+  const handleTestSpeech = () => {
+    if (!canUseTts) {
+      return;
+    }
+
+    speak(
+      "Hello from PregChat. Your assistant will read new replies aloud whenever they arrive.",
+      {
+        rate: 0.96,
+        pitch: 1,
+        volume: 1,
+      },
+    );
+  };
+
+  const micLabel = isListening ? "Stop voice input" : "Start voice input";
+
+  return (
+    <div className="voiceControls" aria-live="polite">
+      <style>{styles}</style>
+      <div className="buttons">
+        <button
+          type="button"
+          className={`btn${isListening ? " recording" : ""}`}
+          onClick={handleToggleRecording}
+          disabled={!canUseStt}
+          aria-pressed={isListening}
+          title={micLabel}
+        >
+          {isListening ? <FiMicOff /> : <FiMic />}
+          {isListening ? "Stop" : "Speak"}
+        </button>
+
+        <button
+          type="button"
+          className="btn"
+          onClick={handleUseText}
+          disabled={!combinedTranscript}
+          title="Insert the captured text into the chat input"
+        >
+          Use Text
+        </button>
+
+        <button
+          type="button"
+          className="btn"
+          onClick={handleTestSpeech}
+          disabled={!canUseTts}
+          title="Play a sample response using text-to-speech"
+        >
+          <FiPlay /> Test TTS
+        </button>
+
+        <button
+          type="button"
+          className="btn"
+          onClick={cancelSpeech}
+          disabled={!canUseTts}
+          title="Stop any ongoing text-to-speech"
+        >
+          <FiSquare /> Stop TTS
+        </button>
+      </div>
+
+      <div className="voiceText">
+        <strong>You said</strong>
+        <p>
+          {transcript}
+          {interim && <span className="interim">{interim}</span>}
+          {!transcript && !interim && "Tap the mic to start speaking"}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default VoiceControls;

--- a/client/src/components/voiceControls.styles.scss
+++ b/client/src/components/voiceControls.styles.scss
@@ -1,0 +1,106 @@
+.voiceControls {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(20, 24, 36, 0.95), rgba(15, 18, 28, 0.85));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: #f0f4ff;
+  font-size: 0.85rem;
+}
+
+.voiceControls .buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.btn {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 0.85rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: transform 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.btn:not(:disabled):hover {
+  background: rgba(255, 255, 255, 0.16);
+  transform: translateY(-1px);
+}
+
+.btn.recording {
+  background: rgba(248, 92, 125, 0.92);
+  color: #fff;
+  box-shadow: 0 0 0 0 rgba(248, 92, 125, 0.6);
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(248, 92, 125, 0.45);
+  }
+  70% {
+    box-shadow: 0 0 0 12px rgba(248, 92, 125, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(248, 92, 125, 0);
+  }
+}
+
+.voiceText {
+  background: rgba(10, 12, 20, 0.65);
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+  min-height: 2.5rem;
+  line-height: 1.4;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.voiceText strong {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.52);
+}
+
+.voiceText p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.92);
+  word-break: break-word;
+}
+
+.interim {
+  display: inline;
+  color: rgba(120, 173, 255, 0.85);
+  font-style: italic;
+  margin-left: 0.25rem;
+}
+
+@media (max-width: 520px) {
+  .voiceControls {
+    padding: 0.65rem;
+    font-size: 0.8rem;
+  }
+
+  .btn {
+    flex: 1 1 45%;
+    justify-content: center;
+  }
+}

--- a/client/src/hooks/useVoice.js
+++ b/client/src/hooks/useVoice.js
@@ -1,0 +1,273 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const getSpeechRecognition = () => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return window.SpeechRecognition || window.webkitSpeechRecognition || null;
+};
+
+const sanitizeNumber = (value, fallback, min = 0, max = 2) => {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return fallback;
+  }
+
+  if (value < min) {
+    return min;
+  }
+
+  if (value > max) {
+    return max;
+  }
+
+  return value;
+};
+
+const useVoice = (options = {}) => {
+  const {
+    lang = "en-US",
+    interimResults = true,
+    continuous = false,
+    autoSendOnFinal = false,
+    onFinalTranscript,
+  } = options;
+
+  const recognitionRef = useRef(null);
+  const utteranceRef = useRef(null);
+  const finalCallbackRef = useRef({ autoSendOnFinal, onFinalTranscript });
+  const [supported, setSupported] = useState({ stt: false, tts: false });
+  const [isListening, setIsListening] = useState(false);
+  const [transcript, setTranscriptState] = useState("");
+  const [interim, setInterim] = useState("");
+
+  useEffect(() => {
+    finalCallbackRef.current = { autoSendOnFinal, onFinalTranscript };
+  }, [autoSendOnFinal, onFinalTranscript]);
+
+  useEffect(() => {
+    const Recognition = getSpeechRecognition();
+    const isClient = typeof window !== "undefined";
+    const hasTts = Boolean(isClient && window.speechSynthesis);
+
+    setSupported({ stt: Boolean(Recognition), tts: hasTts });
+
+    if (!Recognition) {
+      recognitionRef.current = null;
+      return () => {};
+    }
+
+    const recognition = new Recognition();
+    recognition.lang = lang;
+    recognition.interimResults = interimResults;
+    recognition.continuous = continuous;
+
+    recognition.onstart = () => {
+      setIsListening(true);
+    };
+
+    recognition.onend = () => {
+      setIsListening(false);
+      setInterim("");
+    };
+
+    recognition.onerror = () => {
+      setIsListening(false);
+    };
+
+    recognition.onresult = (event) => {
+      let interimTranscript = "";
+      let finalTranscript = "";
+
+      for (let i = event.resultIndex; i < event.results.length; i += 1) {
+        const result = event.results[i];
+        const text = result[0]?.transcript?.trim();
+
+        if (!text) {
+          continue;
+        }
+
+        if (result.isFinal) {
+          finalTranscript = finalTranscript
+            ? `${finalTranscript} ${text}`
+            : text;
+        } else {
+          interimTranscript = interimTranscript
+            ? `${interimTranscript} ${text}`
+            : text;
+        }
+      }
+
+      if (interimTranscript) {
+        setInterim(interimTranscript);
+      } else {
+        setInterim("");
+      }
+
+      if (finalTranscript) {
+        setTranscriptState((prev) => {
+          if (!prev) {
+            return finalTranscript;
+          }
+
+          return `${prev} ${finalTranscript}`.trim();
+        });
+        setInterim("");
+
+        const { autoSendOnFinal: shouldAutoSend, onFinalTranscript: finalCb } =
+          finalCallbackRef.current;
+
+        if (shouldAutoSend && typeof finalCb === "function") {
+          finalCb(finalTranscript);
+        }
+      }
+    };
+
+    recognitionRef.current = recognition;
+
+    return () => {
+      recognition.onresult = null;
+      recognition.onstart = null;
+      recognition.onend = null;
+      recognition.onerror = null;
+
+      try {
+        recognition.stop();
+      } catch (error) {
+        // Ignore cleanup errors when recognition was never started.
+      }
+
+      recognitionRef.current = null;
+    };
+  }, [lang, interimResults, continuous]);
+
+  const cancelSpeech = useCallback(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const synth = window.speechSynthesis;
+
+    if (!synth) {
+      return;
+    }
+
+    synth.cancel();
+    utteranceRef.current = null;
+  }, []);
+
+  const speak = useCallback(
+    (text, speakOptions = {}) => {
+      if (typeof window === "undefined") {
+        return;
+      }
+
+      if (!supported.tts) {
+        return;
+      }
+
+      const phrase = typeof text === "string" ? text.trim() : "";
+
+      if (!phrase) {
+        return;
+      }
+
+      const synth = window.speechSynthesis;
+
+      if (!synth) {
+        return;
+      }
+
+      const {
+        rate = 1,
+        pitch = 1,
+        volume = 1,
+        lang: speakLang,
+      } = speakOptions;
+
+      cancelSpeech();
+
+      const utterance = new SpeechSynthesisUtterance(phrase);
+      utterance.rate = sanitizeNumber(rate, 1, 0.1, 2);
+      utterance.pitch = sanitizeNumber(pitch, 1, 0, 2);
+      utterance.volume = sanitizeNumber(volume, 1, 0, 1);
+      utterance.lang = speakLang || lang;
+
+      synth.speak(utterance);
+      utteranceRef.current = utterance;
+    },
+    [cancelSpeech, lang, supported.tts],
+  );
+
+  const start = useCallback(() => {
+    const recognition = recognitionRef.current;
+
+    if (!recognition) {
+      return;
+    }
+
+    cancelSpeech();
+    setTranscriptState("");
+    setInterim("");
+
+    recognition.lang = lang;
+    recognition.interimResults = interimResults;
+    recognition.continuous = continuous;
+
+    try {
+      recognition.start();
+    } catch (error) {
+      const message = error?.message || "";
+      if (!message.includes("start") && !message.includes("active")) {
+        console.error(error);
+      }
+    }
+  }, [cancelSpeech, lang, interimResults, continuous]);
+
+  const stop = useCallback(() => {
+    const recognition = recognitionRef.current;
+
+    if (!recognition) {
+      return;
+    }
+
+    try {
+      recognition.stop();
+    } catch (error) {
+      const message = error?.message || "";
+      if (!message.includes("not active")) {
+        console.error(error);
+      }
+    }
+  }, []);
+
+  useEffect(
+    () => () => {
+      try {
+        stop();
+      } catch (error) {
+        // Ignore cleanup errors
+      }
+      cancelSpeech();
+    },
+    [stop, cancelSpeech],
+  );
+
+  const setTranscript = useCallback((value) => {
+    setTranscriptState(value);
+  }, []);
+
+  return {
+    supported,
+    isListening,
+    transcript,
+    interim,
+    start,
+    stop,
+    speak,
+    cancelSpeech,
+    setTranscript,
+  };
+};
+
+export default useVoice;


### PR DESCRIPTION
## Summary
- add a reusable `useVoice` hook that wraps the Web Speech API for recognition and synthesis
- introduce `VoiceControls` with styling and wire it into the chat input component
- extend the chat window to auto speak the latest assistant reply with text-to-speech

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d5fedad3b48330bc4cf3516aa53de0