### PR TITLE
Add voice mode chat experience

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -23,6 +23,7 @@ import MyAppointments from "./pages/MyAppointments.jsx";
 import JournalsList from "./pages/JournalsList.jsx";
 import JournalForm from "./pages/JournalForm.jsx";
 import JournalDetail from "./pages/JournalDetail.jsx";
+import VoiceChat from "./pages/voice/VoiceChat.jsx";
 
 const App = () => {
   const token = useAppSelector(selectAuthToken);
@@ -98,6 +99,12 @@ const App = () => {
             path="/chat"
             element={
               isAuthenticated ? <Chat /> : <Navigate to="/login" replace />
+            }
+          />
+          <Route
+            path="/voice"
+            element={
+              isAuthenticated ? <VoiceChat /> : <Navigate to="/login" replace />
             }
           />
           <Route

--- a/client/src/api/http.js
+++ b/client/src/api/http.js
@@ -17,6 +17,20 @@ const parseJsonSafe = async (response) => {
   }
 };
 
+const parseResponse = async (response, responseType) => {
+  switch (responseType) {
+    case "blob":
+      return response.blob();
+    case "arrayBuffer":
+      return response.arrayBuffer();
+    case "text":
+      return response.text();
+    case "json":
+    default:
+      return parseJsonSafe(response);
+  }
+};
+
 const shouldRetry = (status) => status >= 500 && status < 600;
 
 const buildHeaders = (headers = {}) => {
@@ -52,6 +66,7 @@ const prepareBody = (options, headers) => {
 export const httpRequest = async (path, options = {}) => {
   const retries = options.retries ?? 2;
   const retryDelay = options.retryDelay ?? 300;
+  const responseType = options.responseType ?? "json";
   let attempt = 0;
   let lastError = null;
 
@@ -72,7 +87,7 @@ export const httpRequest = async (path, options = {}) => {
       });
 
       if (response.ok) {
-        return parseJsonSafe(response);
+        return parseResponse(response, responseType);
       }
 
       const payload = await parseJsonSafe(response);

--- a/client/src/components/ChatInput.jsx
+++ b/client/src/components/ChatInput.jsx
@@ -1,4 +1,6 @@
 import React, { useCallback, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import content from "../content/appContent.json";
 import { FiSend } from "react-icons/fi";
 import VoiceControls from "./VoiceControls.jsx";
 import "./chatInput.styles.scss";
@@ -9,7 +11,9 @@ const ChatInput = ({
   isSending = false,
   autoFocus = true,
 }) => {
+  const navigate = useNavigate();
   const [value, setValue] = useState("");
+  const voiceLaunchLabel = content.voice?.page?.controls?.launch ?? "Voice Mode";
   const inputRef = useRef(null);
 
   const handleSend = useCallback(
@@ -83,7 +87,17 @@ const ChatInput = ({
         </div>
       </form>
 
-      <VoiceControls onSend={handleVoiceSend} />
+      <div className="chatInput__extras">
+        <VoiceControls onSend={handleVoiceSend} />
+
+        <button
+          type="button"
+          className="chatInput__voiceMode"
+          onClick={() => navigate("/voice")}
+        >
+          {voiceLaunchLabel}
+        </button>
+      </div>
     </div>
   );
 };

--- a/client/src/components/chatInput.styles.scss
+++ b/client/src/components/chatInput.styles.scss
@@ -1,0 +1,106 @@
+.chatInput {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  &__form {
+    display: flex;
+  }
+
+  &__field {
+    flex: 1;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.75rem;
+    align-items: center;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 999px;
+    padding: 0.75rem 1rem;
+  }
+
+  &__input {
+    width: 100%;
+    border: none;
+    background: transparent;
+    color: inherit;
+    font-size: 1rem;
+    outline: none;
+
+    &::placeholder {
+      color: rgba(255, 255, 255, 0.4);
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+
+  &__send {
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 50%;
+    border: none;
+    background: linear-gradient(135deg, #4c8bf5, #8c5ce6);
+    color: #ffffff;
+    display: grid;
+    place-items: center;
+    font-size: 1.25rem;
+    cursor: pointer;
+    transition: transform 150ms ease, opacity 150ms ease;
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &:not(:disabled):hover {
+      transform: translateY(-1px) scale(1.02);
+    }
+  }
+
+  &__extras {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  &__voiceMode {
+    border: 1px solid rgba(76, 139, 245, 0.6);
+    background: rgba(76, 139, 245, 0.12);
+    color: #dbe7ff;
+    padding: 0.75rem 1.25rem;
+    border-radius: 999px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 150ms ease, transform 150ms ease;
+
+    &:hover {
+      background: rgba(76, 139, 245, 0.2);
+      transform: translateY(-1px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(76, 139, 245, 0.9);
+      outline-offset: 3px;
+    }
+  }
+}
+
+@media (max-width: 720px) {
+  .chatInput {
+    gap: 1rem;
+
+    &__field {
+      padding: 0.5rem 0.75rem;
+    }
+
+    &__voiceMode {
+      width: 100%;
+      text-align: center;
+    }
+  }
+}

--- a/client/src/content/appContent.json
+++ b/client/src/content/appContent.json
@@ -95,6 +95,40 @@
     "playAgain": "Play Again",
     "resume": "Resuming your latest face-off..."
   },
+  "voice": {
+    "page": {
+      "title": "Voice Mode",
+      "betaTag": "(beta)",
+      "back": "Back to chat",
+      "triageFlag": "Important",
+      "controls": {
+        "launch": "Voice Mode",
+        "start": "Start voice mode",
+        "stop": "Stop listening",
+        "processing": "Processing...",
+        "typeInstead": "Type instead",
+        "replay": "Replay last reply"
+      },
+      "status": {
+        "listening": "Listening...",
+        "processing": "Processing your message..."
+      },
+      "messages": {
+        "permission": "Enable mic access in site settings",
+        "noSpeech": "Didn't catch that—try again",
+        "recognition": "We couldn't start voice recognition right now."
+      },
+      "errors": {
+        "permission": "Enable mic access in site settings",
+        "recognition": "Voice recognition isn't available right now.",
+        "transcription": "We couldn't transcribe that just now.",
+        "recording": "We couldn't access your microphone.",
+        "unsupported": "Your browser doesn't support voice recording yet.",
+        "response": "Aya couldn't respond right now. Please try again.",
+        "tts": "We couldn't play that response aloud."
+      }
+    }
+  },
   "journals": {
     "list": {
       "title": "Daily journals",

--- a/client/src/hooks/useVoice.js
+++ b/client/src/hooks/useVoice.js
@@ -31,19 +31,48 @@ const useVoice = (options = {}) => {
     continuous = false,
     autoSendOnFinal = false,
     onFinalTranscript,
+    onError,
+    onListenStart,
+    onListenEnd,
+    onSpeakStart,
+    onSpeakEnd,
   } = options;
 
   const recognitionRef = useRef(null);
   const utteranceRef = useRef(null);
-  const finalCallbackRef = useRef({ autoSendOnFinal, onFinalTranscript });
+  const optionsRef = useRef({
+    autoSendOnFinal,
+    onFinalTranscript,
+    onError,
+    onListenStart,
+    onListenEnd,
+    onSpeakStart,
+    onSpeakEnd,
+  });
   const [supported, setSupported] = useState({ stt: false, tts: false });
   const [isListening, setIsListening] = useState(false);
   const [transcript, setTranscriptState] = useState("");
   const [interim, setInterim] = useState("");
 
   useEffect(() => {
-    finalCallbackRef.current = { autoSendOnFinal, onFinalTranscript };
-  }, [autoSendOnFinal, onFinalTranscript]);
+    optionsRef.current = {
+      autoSendOnFinal,
+      onFinalTranscript,
+      onError,
+      onListenStart,
+      onListenEnd,
+      onSpeakStart,
+      onSpeakEnd,
+    };
+  }, [
+    autoSendOnFinal,
+    onFinalTranscript,
+    onError,
+    onListenStart,
+    onListenEnd,
+    onSpeakStart,
+    onSpeakEnd,
+  ]);
 
   useEffect(() => {
     const Recognition = getSpeechRecognition();
@@ -64,15 +93,31 @@ const useVoice = (options = {}) => {
 
     recognition.onstart = () => {
       setIsListening(true);
+      const { onListenStart: handleListenStart } = optionsRef.current;
+      if (typeof handleListenStart === "function") {
+        handleListenStart();
+      }
     };
 
     recognition.onend = () => {
       setIsListening(false);
       setInterim("");
+      const { onListenEnd: handleListenEnd } = optionsRef.current;
+      if (typeof handleListenEnd === "function") {
+        handleListenEnd();
+      }
     };
 
-    recognition.onerror = () => {
+    recognition.onerror = (event) => {
       setIsListening(false);
+      const { onError: handleError, onListenEnd: handleListenEnd } =
+        optionsRef.current;
+      if (typeof handleError === "function") {
+        handleError(event);
+      }
+      if (typeof handleListenEnd === "function") {
+        handleListenEnd();
+      }
     };
 
     recognition.onresult = (event) => {
@@ -115,7 +160,7 @@ const useVoice = (options = {}) => {
         setInterim("");
 
         const { autoSendOnFinal: shouldAutoSend, onFinalTranscript: finalCb } =
-          finalCallbackRef.current;
+          optionsRef.current;
 
         if (shouldAutoSend && typeof finalCb === "function") {
           finalCb(finalTranscript);
@@ -154,6 +199,10 @@ const useVoice = (options = {}) => {
 
     synth.cancel();
     utteranceRef.current = null;
+    const { onSpeakEnd: handleSpeakEnd } = optionsRef.current;
+    if (typeof handleSpeakEnd === "function") {
+      handleSpeakEnd();
+    }
   }, []);
 
   const speak = useCallback(
@@ -195,6 +244,23 @@ const useVoice = (options = {}) => {
 
       synth.speak(utterance);
       utteranceRef.current = utterance;
+      const { onSpeakStart: handleSpeakStart, onSpeakEnd: handleSpeakEnd } =
+        optionsRef.current;
+      if (typeof handleSpeakStart === "function") {
+        handleSpeakStart();
+      }
+      utterance.onend = () => {
+        utteranceRef.current = null;
+        if (typeof handleSpeakEnd === "function") {
+          handleSpeakEnd();
+        }
+      };
+      utterance.onerror = () => {
+        utteranceRef.current = null;
+        if (typeof handleSpeakEnd === "function") {
+          handleSpeakEnd();
+        }
+      };
     },
     [cancelSpeech, lang, supported.tts],
   );

--- a/client/src/pages/voice/VoiceChat.jsx
+++ b/client/src/pages/voice/VoiceChat.jsx
@@ -1,0 +1,698 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { FiArrowLeft, FiLoader, FiMic, FiRotateCcw, FiSquare, FiType } from "react-icons/fi";
+import { useNavigate } from "react-router-dom";
+import content from "../../content/appContent.json";
+import { http } from "../../api/http.js";
+import { useChatMessages } from "../../features/messages/hooks/useChatMessages.js";
+import { useTodayPregnancyQuery } from "../../features/pregnancy/hooks/usePregnancy.js";
+import useVoice from "../../hooks/useVoice.js";
+import styles from "./voiceChat.styles.module.scss";
+
+const formatTime = (value) => {
+  try {
+    return new Date(value).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch (error) {
+    return "";
+  }
+};
+
+const genId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+const VoiceChat = () => {
+  const navigate = useNavigate();
+  const pageCopy = content.voice?.page ?? {};
+  const controlsCopy = pageCopy.controls ?? {};
+  const statusCopy = pageCopy.status ?? {};
+  const messageCopy = pageCopy.messages ?? {};
+  const errorCopy = pageCopy.errors ?? {};
+
+  const conversationRef = useRef(null);
+  const audioRef = useRef(null);
+  const audioUrlRef = useRef(null);
+  const recorderRef = useRef(null);
+  const recordedChunksRef = useRef([]);
+  const usingFallbackRef = useRef(false);
+  const transcriptRef = useRef("");
+  const transcriptHandlerRef = useRef(() => {});
+  const micStateRef = useRef("idle");
+
+  const [micState, setMicStateValue] = useState("idle");
+  const [statusMessage, setStatusMessage] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [lastAssistantReply, setLastAssistantReply] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const [isSpeaking, setIsSpeaking] = useState(false);
+
+  const { messages, appendMessages } = useChatMessages();
+  const { data: daySummary } = useTodayPregnancyQuery({ enabled: true });
+
+  const setMicState = useCallback((next) => {
+    micStateRef.current = next;
+    setMicStateValue(next);
+  }, []);
+
+  useEffect(() => {
+    if (micState === "recording") {
+      setStatusMessage(statusCopy.listening || "");
+    } else if (micState === "processing") {
+      setStatusMessage(statusCopy.processing || "");
+    } else {
+      setStatusMessage("");
+    }
+  }, [micState, statusCopy.listening, statusCopy.processing]);
+
+  const stopPlayback = useCallback(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.currentTime = 0;
+      audioRef.current.onended = null;
+      audioRef.current.onerror = null;
+      audioRef.current = null;
+    }
+
+    if (audioUrlRef.current) {
+      URL.revokeObjectURL(audioUrlRef.current);
+      audioUrlRef.current = null;
+    }
+
+    setIsSpeaking(false);
+  }, []);
+
+  const handleSpeakStart = useCallback(() => {
+    setIsSpeaking(true);
+  }, []);
+
+  const handleSpeakEnd = useCallback(() => {
+    setIsSpeaking(false);
+  }, []);
+
+  const handleListenStart = useCallback(() => {
+    setErrorMessage("");
+    setMicState("recording");
+  }, [setMicState]);
+
+  const handleNoSpeech = useCallback(() => {
+    if (messageCopy.noSpeech) {
+      setErrorMessage(messageCopy.noSpeech);
+    }
+  }, [messageCopy.noSpeech]);
+
+  const handleListenEnd = useCallback(() => {
+    if (micStateRef.current === "recording" && !transcriptRef.current) {
+      setMicState("idle");
+      handleNoSpeech();
+    }
+  }, [handleNoSpeech, setMicState]);
+
+  const handleVoiceError = useCallback(
+    (event) => {
+      setMicState("idle");
+      const type = event?.error;
+
+      if (type === "not-allowed" || type === "service-not-allowed") {
+        setErrorMessage(
+          errorCopy.permission || messageCopy.permission || "Enable mic access in site settings",
+        );
+        return;
+      }
+
+      if (type === "no-speech") {
+        handleNoSpeech();
+        return;
+      }
+
+      const fallback =
+        errorCopy.recognition || messageCopy.recognition || "We couldn't start voice recognition.";
+      setErrorMessage(fallback);
+    },
+    [errorCopy.permission, errorCopy.recognition, handleNoSpeech, messageCopy.permission, messageCopy.recognition, setMicState],
+  );
+
+  const {
+    supported,
+    transcript,
+    start,
+    stop,
+    speak,
+    cancelSpeech,
+    setTranscript,
+  } = useVoice({
+    continuous: false,
+    interimResults: true,
+    autoSendOnFinal: true,
+    onFinalTranscript: (finalTranscript) => {
+      const phrase = finalTranscript?.trim() || "";
+      transcriptRef.current = phrase;
+      transcriptHandlerRef.current(phrase);
+    },
+    onError: handleVoiceError,
+    onListenStart: handleListenStart,
+    onListenEnd: handleListenEnd,
+    onSpeakStart: handleSpeakStart,
+    onSpeakEnd: handleSpeakEnd,
+  });
+
+  useEffect(() => {
+    transcriptRef.current = transcript?.trim() || "";
+  }, [transcript]);
+
+  useEffect(() => {
+    const latestAssistant = [...(messages ?? [])]
+      .reverse()
+      .find((entry) => entry?.role === "assistant" && entry?.content);
+
+    if (latestAssistant) {
+      setLastAssistantReply(latestAssistant.content);
+    } else {
+      setLastAssistantReply("");
+    }
+  }, [messages]);
+
+  useEffect(() => {
+    const node = conversationRef.current;
+    if (!node) {
+      return;
+    }
+
+    node.scrollTop = node.scrollHeight;
+  }, [messages?.length, isSending]);
+
+  useEffect(
+    () => () => {
+      stopPlayback();
+      cancelSpeech();
+      if (recorderRef.current && recorderRef.current.state !== "inactive") {
+        try {
+          recorderRef.current.stop();
+        } catch (error) {
+          // ignore cleanup errors
+        }
+      }
+    },
+    [stopPlayback, cancelSpeech],
+  );
+
+  const speakReply = useCallback(
+    async (text) => {
+      const phrase = (text || "").trim();
+      if (!phrase) {
+        return;
+      }
+
+      stopPlayback();
+      cancelSpeech();
+
+      if (supported.tts) {
+        speak(phrase, {
+          rate: 0.96,
+          pitch: 1,
+          volume: 1,
+        });
+        return;
+      }
+
+      try {
+        const audioBlob = await http.post("/api/speech/tts", {
+          json: { text: phrase },
+          responseType: "blob",
+        });
+
+        if (!(audioBlob instanceof Blob)) {
+          setErrorMessage(errorCopy.tts || "");
+          return;
+        }
+
+        const url = URL.createObjectURL(audioBlob);
+        audioUrlRef.current = url;
+        const audio = new Audio(url);
+        audioRef.current = audio;
+        setIsSpeaking(true);
+
+        audio.onended = () => {
+          setIsSpeaking(false);
+          if (audioUrlRef.current) {
+            URL.revokeObjectURL(audioUrlRef.current);
+            audioUrlRef.current = null;
+          }
+          audioRef.current = null;
+        };
+
+        audio.onerror = () => {
+          setIsSpeaking(false);
+          if (audioUrlRef.current) {
+            URL.revokeObjectURL(audioUrlRef.current);
+            audioUrlRef.current = null;
+          }
+          audioRef.current = null;
+          setErrorMessage(errorCopy.tts || "");
+        };
+
+        await audio.play();
+      } catch (error) {
+        setIsSpeaking(false);
+        setErrorMessage(error?.message || errorCopy.tts || "");
+      }
+    },
+    [cancelSpeech, errorCopy.tts, speak, stopPlayback, supported.tts],
+  );
+
+  const sendMessage = useCallback(
+    async (text) => {
+      const cleaned = (text || "").trim();
+      if (!cleaned) {
+        return;
+      }
+
+      const timestamp = new Date().toISOString();
+      const userMessage = {
+        id: genId(),
+        role: "user",
+        content: cleaned,
+        timestamp,
+      };
+
+      await appendMessages(userMessage);
+      setIsSending(true);
+
+      try {
+        const payload = {
+          text: cleaned,
+          ...(daySummary
+            ? {
+                dayData: {
+                  dayIndex: daySummary.day,
+                  babyUpdate: daySummary.babyUpdate,
+                  momUpdate: daySummary.momUpdate,
+                  tips: daySummary.tips,
+                },
+              }
+            : {}),
+        };
+
+        const data = await http.post("/chat/ask", { json: payload });
+        const assistantContent =
+          data?.content ||
+          data?.message ||
+          errorCopy.response ||
+          "I'm not sure how to respond right now, but I'm here for you.";
+
+        const assistantMessage = {
+          id: genId(),
+          role: "assistant",
+          content: assistantContent,
+          timestamp: new Date().toISOString(),
+          meta: data?.triage ? { triage: true } : undefined,
+        };
+
+        await appendMessages(assistantMessage);
+        setLastAssistantReply(assistantContent);
+        await speakReply(assistantContent);
+        setErrorMessage("");
+      } catch (error) {
+        const fallback = error?.message || errorCopy.response || "Failed to send message.";
+        await appendMessages({
+          id: genId(),
+          role: "assistant",
+          content: fallback,
+          timestamp: new Date().toISOString(),
+        });
+        setErrorMessage(fallback);
+        throw error;
+      } finally {
+        setIsSending(false);
+      }
+    },
+    [appendMessages, daySummary, errorCopy.response, speakReply],
+  );
+
+  const handleTranscript = useCallback(
+    async (rawText, { clearRecognition = false } = {}) => {
+      const text = (rawText || "").trim();
+      if (!text) {
+        setMicState("idle");
+        handleNoSpeech();
+        if (clearRecognition) {
+          setTranscript("");
+        }
+        return;
+      }
+
+      setErrorMessage("");
+      setMicState("processing");
+
+      try {
+        await sendMessage(text);
+      } catch (error) {
+        // error state already handled in sendMessage
+      } finally {
+        setMicState("idle");
+        if (clearRecognition) {
+          setTranscript("");
+          transcriptRef.current = "";
+        }
+      }
+    },
+    [handleNoSpeech, sendMessage, setMicState, setTranscript],
+  );
+
+  useEffect(() => {
+    transcriptHandlerRef.current = (phrase) => {
+      const text = (phrase || "").trim();
+
+      if (!text) {
+        setTranscript("");
+        transcriptRef.current = "";
+        setMicState("idle");
+        handleNoSpeech();
+        return;
+      }
+
+      handleTranscript(text, { clearRecognition: true });
+    };
+  }, [handleNoSpeech, handleTranscript, setMicState, setTranscript]);
+
+  const handleFallbackTranscription = useCallback(
+    async (audioBlob) => {
+      if (!(audioBlob instanceof Blob) || audioBlob.size === 0) {
+        setMicState("idle");
+        handleNoSpeech();
+        return;
+      }
+
+      try {
+        const formData = new FormData();
+        formData.append("audio", audioBlob, `voice-${Date.now()}.webm`);
+
+        const result = await http.post("/api/speech/stt", { body: formData });
+        const text = result?.text?.trim();
+
+        if (!text) {
+          setMicState("idle");
+          handleNoSpeech();
+          return;
+        }
+
+        await handleTranscript(text);
+      } catch (error) {
+        setMicState("idle");
+        const fallback =
+          error?.message || errorCopy.transcription || "We couldn't transcribe that just now.";
+        setErrorMessage(fallback);
+      }
+    },
+    [errorCopy.transcription, handleNoSpeech, handleTranscript, setMicState],
+  );
+
+  const startFallbackRecording = useCallback(async () => {
+    if (typeof window === "undefined") {
+      setErrorMessage(errorCopy.unsupported || "");
+      return;
+    }
+
+    if (!navigator.mediaDevices?.getUserMedia || typeof window.MediaRecorder === "undefined") {
+      setErrorMessage(errorCopy.unsupported || "");
+      return;
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      usingFallbackRef.current = true;
+      recordedChunksRef.current = [];
+      const recorder = new MediaRecorder(stream);
+      recorderRef.current = recorder;
+
+      recorder.onstart = () => {
+        setErrorMessage("");
+        setMicState("recording");
+      };
+
+      recorder.ondataavailable = (event) => {
+        if (event?.data && event.data.size > 0) {
+          recordedChunksRef.current.push(event.data);
+        }
+      };
+
+      recorder.onerror = (event) => {
+        setMicState("idle");
+        const fallback =
+          event?.error?.message || errorCopy.recording || "We couldn't access your microphone.";
+        setErrorMessage(fallback);
+        stream.getTracks().forEach((track) => track.stop());
+        usingFallbackRef.current = false;
+        recorderRef.current = null;
+        recordedChunksRef.current = [];
+      };
+
+      recorder.onstop = async () => {
+        stream.getTracks().forEach((track) => track.stop());
+        usingFallbackRef.current = false;
+        const chunks = recordedChunksRef.current;
+        recordedChunksRef.current = [];
+        recorderRef.current = null;
+        if (!chunks.length) {
+          setMicState("idle");
+          handleNoSpeech();
+          return;
+        }
+
+        const blob = new Blob(chunks, { type: recorder.mimeType || "audio/webm" });
+        setMicState("processing");
+        await handleFallbackTranscription(blob);
+      };
+
+      recorder.start();
+    } catch (error) {
+      usingFallbackRef.current = false;
+      recorderRef.current = null;
+      recordedChunksRef.current = [];
+
+      if (error?.name === "NotAllowedError" || error?.name === "SecurityError") {
+        setErrorMessage(
+          errorCopy.permission || messageCopy.permission || "Enable mic access in site settings",
+        );
+      } else {
+        setErrorMessage(error?.message || errorCopy.recording || "We couldn't access your microphone.");
+      }
+
+      setMicState("idle");
+    }
+  }, [errorCopy.permission, errorCopy.recording, errorCopy.unsupported, handleFallbackTranscription, handleNoSpeech, messageCopy.permission, setMicState]);
+
+  const handleStartRecording = useCallback(() => {
+    setErrorMessage("");
+    stopPlayback();
+    cancelSpeech();
+
+    if (supported.stt) {
+      setTranscript("");
+      transcriptRef.current = "";
+      setMicState("recording");
+      start();
+      return;
+    }
+
+    startFallbackRecording();
+  }, [cancelSpeech, setMicState, setTranscript, start, startFallbackRecording, stopPlayback, supported.stt]);
+
+  const handleStopRecording = useCallback(() => {
+    if (usingFallbackRef.current && recorderRef.current) {
+      try {
+        recorderRef.current.stop();
+        setMicState("processing");
+      } catch (error) {
+        setMicState("idle");
+      }
+      return;
+    }
+
+    if (supported.stt) {
+      setMicState("processing");
+      stop();
+    }
+  }, [setMicState, stop, supported.stt]);
+
+  const handleMicClick = useCallback(() => {
+    if (micState === "processing" || isSending) {
+      return;
+    }
+
+    if (micState === "recording") {
+      handleStopRecording();
+      return;
+    }
+
+    handleStartRecording();
+  }, [handleStartRecording, handleStopRecording, isSending, micState]);
+
+  const micLabel = useMemo(() => {
+    if (micState === "recording") {
+      return controlsCopy.stop || "Stop";
+    }
+
+    if (micState === "processing") {
+      return controlsCopy.processing || "Processing";
+    }
+
+    return controlsCopy.start || "Start";
+  }, [controlsCopy.processing, controlsCopy.start, controlsCopy.stop, micState]);
+
+  const handleReplay = useCallback(() => {
+    if (!lastAssistantReply) {
+      return;
+    }
+
+    speakReply(lastAssistantReply);
+  }, [lastAssistantReply, speakReply]);
+
+  const handleReturnToChat = useCallback(() => {
+    stopPlayback();
+    cancelSpeech();
+
+    if (usingFallbackRef.current && recorderRef.current) {
+      try {
+        recorderRef.current.stop();
+      } catch (error) {
+        // ignore stop errors on navigation
+      }
+      usingFallbackRef.current = false;
+      recordedChunksRef.current = [];
+    } else if (micState === "recording" && supported.stt) {
+      stop();
+    }
+
+    setMicState("idle");
+    setTranscript("");
+    transcriptRef.current = "";
+    navigate("/chat");
+  }, [cancelSpeech, micState, navigate, setMicState, setTranscript, stop, stopPlayback, supported.stt]);
+
+  const micIcon = micState === "recording" ? <FiSquare /> : <FiMic />;
+
+  const renderMessage = (entry, index) => {
+    const tone = entry?.meta?.triage ? "triage" : entry?.role;
+    const key = entry?.id || entry?.timestamp || index;
+    const bubbleClass =
+      tone === "user"
+        ? `${styles.voiceChat__bubble} ${styles.voiceChat__bubbleUser}`
+        : tone === "triage"
+        ? `${styles.voiceChat__bubble} ${styles.voiceChat__bubbleTriage}`
+        : `${styles.voiceChat__bubble} ${styles.voiceChat__bubbleAssistant}`;
+
+    return (
+      <div key={key} className={bubbleClass}>
+        <div className={styles.voiceChat__bubbleBody}>
+          {entry?.meta?.triage && (
+            <span className={styles.voiceChat__flag}>{pageCopy.triageFlag || "Important"}</span>
+          )}
+          <p>{entry?.content}</p>
+        </div>
+        <time className={styles.voiceChat__bubbleTime}>{formatTime(entry?.timestamp)}</time>
+      </div>
+    );
+  };
+
+  return (
+    <main className={styles.voiceChat}>
+      <header className={styles.voiceChat__header}>
+        <div className={styles.voiceChat__nav}>
+          <button
+            type="button"
+            className={styles.voiceChat__back}
+            onClick={handleReturnToChat}
+          >
+            <FiArrowLeft aria-hidden="true" />
+            {pageCopy.back || "Back"}
+          </button>
+        </div>
+
+        <div className={styles.voiceChat__titleGroup}>
+          <span>{pageCopy.title || "Voice Mode"}</span>
+          <span className={styles.voiceChat__beta}>{pageCopy.betaTag || "Beta"}</span>
+        </div>
+      </header>
+
+      <section ref={conversationRef} className={styles.voiceChat__conversation}>
+        <div className={styles.voiceChat__bubbles}>
+          {messages?.map(renderMessage)}
+
+          {isSending && (
+            <div className={`${styles.voiceChat__bubble} ${styles.voiceChat__bubbleAssistant}`}>
+              <div className={styles.voiceChat__bubbleBody}>
+                <div className={styles.voiceChat__typing} aria-hidden="true">
+                  <span />
+                  <span />
+                  <span />
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <footer className={styles.voiceChat__dock}>
+        <div className={styles.voiceChat__statusWrap} aria-live="polite">
+          {errorMessage ? (
+            <p className={`${styles.voiceChat__status} ${styles.voiceChat__statusError}`}>
+              {errorMessage}
+            </p>
+          ) : (
+            <p className={styles.voiceChat__status}>{statusMessage}</p>
+          )}
+        </div>
+
+        <div className={styles.voiceChat__micRow}>
+          <button
+            type="button"
+            className={`${styles.voiceChat__micButton} ${
+              micState === "recording" ? "recording" : ""
+            } ${micState === "processing" ? "processing" : ""}`.trim()}
+            onClick={handleMicClick}
+            disabled={micState === "processing" || isSending}
+          >
+            {micState === "processing" ? (
+              <FiLoader className={styles.voiceChat__spinner} aria-hidden="true" />
+            ) : (
+              micIcon
+            )}
+            <span>{micLabel}</span>
+            {isSpeaking && <span aria-live="polite">•</span>}
+          </button>
+
+          <div className={styles.voiceChat__dockButtons}>
+            <button
+              type="button"
+              className={styles.voiceChat__secondaryButton}
+              onClick={handleReturnToChat}
+            >
+              <FiType aria-hidden="true" /> {controlsCopy.typeInstead || "Type instead"}
+            </button>
+
+            <button
+              type="button"
+              className={styles.voiceChat__secondaryButton}
+              onClick={handleReplay}
+              disabled={!lastAssistantReply}
+            >
+              <FiRotateCcw aria-hidden="true" /> {controlsCopy.replay || "Replay last reply"}
+            </button>
+          </div>
+        </div>
+      </footer>
+    </main>
+  );
+};
+
+export default VoiceChat;

--- a/client/src/pages/voice/voiceChat.styles.module.scss
+++ b/client/src/pages/voice/voiceChat.styles.module.scss
@@ -1,0 +1,3 @@
+@use "./voiceChat.styles.scss" as voice;
+
+@include voice.voiceChat();

--- a/client/src/pages/voice/voiceChat.styles.scss
+++ b/client/src/pages/voice/voiceChat.styles.scss
@@ -1,0 +1,348 @@
+@mixin voiceChat {
+  .voiceChat {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    background: radial-gradient(circle at top, #16203a 0%, #0b111f 55%, #05070c 100%);
+    color: #f5f7ff;
+
+    &__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1.5rem clamp(1rem, 4vw, 3rem) 1rem;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      background: rgba(4, 9, 18, 0.7);
+      backdrop-filter: blur(12px);
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+
+    &__nav {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    &__back {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.65rem 1rem;
+      border-radius: 999px;
+      border: 1px solid rgba(245, 247, 255, 0.2);
+      background: rgba(12, 21, 38, 0.9);
+      color: inherit;
+      cursor: pointer;
+      transition: transform 150ms ease, background 150ms ease, border 150ms ease;
+
+      &:hover {
+        transform: translateY(-1px);
+        background: rgba(28, 44, 76, 0.9);
+        border-color: rgba(245, 247, 255, 0.4);
+      }
+
+      &:focus-visible {
+        outline: 2px solid rgba(134, 179, 255, 0.8);
+        outline-offset: 3px;
+      }
+    }
+
+    &__titleGroup {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: clamp(1.25rem, 2vw, 1.75rem);
+      font-weight: 700;
+    }
+
+    &__beta {
+      font-size: 0.85rem;
+      padding: 0.35rem 0.75rem;
+      border-radius: 999px;
+      background: rgba(134, 179, 255, 0.16);
+      color: #9fc0ff;
+      border: 1px solid rgba(134, 179, 255, 0.4);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    &__conversation {
+      flex: 1;
+      overflow-y: auto;
+      padding: clamp(1rem, 3vw, 2.5rem) clamp(1rem, 6vw, 4.5rem);
+      display: flex;
+      justify-content: center;
+    }
+
+    &__bubbles {
+      width: 100%;
+      max-width: 720px;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    &__bubble {
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    &__bubbleBody {
+      padding: 1rem 1.25rem;
+      border-radius: 1.25rem;
+      line-height: 1.5;
+      max-width: 100%;
+      width: fit-content;
+      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
+      background: rgba(14, 22, 37, 0.9);
+    }
+
+    &__bubbleTime {
+      font-size: 0.75rem;
+      color: rgba(245, 247, 255, 0.55);
+      justify-self: flex-start;
+    }
+
+    &__bubbleUser {
+      justify-items: end;
+
+      .voiceChat__bubbleBody {
+        background: linear-gradient(135deg, #4c8bf5, #8c5ce6);
+        color: #ffffff;
+        border-top-right-radius: 0.5rem;
+      }
+
+      .voiceChat__bubbleTime {
+        justify-self: flex-end;
+      }
+    }
+
+    &__bubbleAssistant {
+      .voiceChat__bubbleBody {
+        border-top-left-radius: 0.5rem;
+      }
+    }
+
+    &__bubbleTriage {
+      .voiceChat__bubbleBody {
+        border-top-left-radius: 0.5rem;
+        border: 1px solid rgba(255, 202, 58, 0.8);
+        background: rgba(58, 47, 10, 0.8);
+        color: #ffe9a6;
+      }
+
+      .voiceChat__flag {
+        display: inline-block;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        background: rgba(255, 202, 58, 0.2);
+        color: #ffce55;
+        padding: 0.25rem 0.75rem;
+        border-radius: 999px;
+        margin-bottom: 0.5rem;
+      }
+    }
+
+    &__statusWrap {
+      min-height: 1.5rem;
+    }
+
+    &__status {
+      min-height: 1.5rem;
+      color: rgba(245, 247, 255, 0.75);
+      font-size: 0.95rem;
+    }
+
+    &__statusError {
+      color: #ff9ca3;
+    }
+
+    &__dock {
+      position: sticky;
+      bottom: 0;
+      padding: 1.75rem clamp(1rem, 4vw, 3rem) calc(1.75rem + env(safe-area-inset-bottom));
+      background: linear-gradient(180deg, rgba(5, 8, 15, 0.2) 0%, rgba(5, 8, 15, 0.85) 45%, #05080f 100%);
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    &__micRow {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+      justify-content: space-between;
+      flex-wrap: wrap;
+    }
+
+    &__micButton {
+      flex: 1;
+      min-width: 220px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      padding: 1rem 1.5rem;
+      border-radius: 999px;
+      border: none;
+      font-size: 1.1rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease;
+      background: linear-gradient(135deg, #ff477e, #ff7b54);
+      color: #fff;
+      box-shadow: 0 12px 30px rgba(255, 120, 120, 0.35);
+
+      &.recording {
+        background: linear-gradient(135deg, #ec3751, #ff9f43);
+        box-shadow: 0 0 0 0 rgba(255, 123, 84, 0.45);
+        animation: pulseGlow 1.6s ease-in-out infinite;
+      }
+
+      &.processing {
+        background: linear-gradient(135deg, #3743ec, #5c8cff);
+        box-shadow: 0 8px 24px rgba(92, 140, 255, 0.35);
+        cursor: wait;
+      }
+
+      &:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+        box-shadow: none;
+      }
+    }
+
+    &__dockButtons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    &__secondaryButton {
+      border-radius: 999px;
+      border: 1px solid rgba(159, 192, 255, 0.4);
+      background: rgba(14, 22, 37, 0.7);
+      color: #d6e3ff;
+      padding: 0.75rem 1.25rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 150ms ease, border 150ms ease, transform 150ms ease;
+
+      &:hover {
+        border-color: rgba(159, 192, 255, 0.6);
+        background: rgba(26, 36, 58, 0.9);
+        transform: translateY(-1px);
+      }
+
+      &:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
+    }
+
+    &__typing {
+      display: inline-flex;
+      gap: 0.4rem;
+      align-items: center;
+
+      span {
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: 50%;
+        background: rgba(245, 247, 255, 0.7);
+        animation: bounce 1.2s infinite ease-in-out;
+
+        &:nth-child(2) {
+          animation-delay: 0.15s;
+        }
+
+        &:nth-child(3) {
+          animation-delay: 0.3s;
+        }
+      }
+    }
+
+    &__spinner {
+      animation: spin 1s linear infinite;
+    }
+  }
+
+  @keyframes bounce {
+    0%,
+    80%,
+    100% {
+      transform: scale(0.8);
+      opacity: 0.4;
+    }
+    40% {
+      transform: scale(1);
+      opacity: 1;
+    }
+  }
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @keyframes pulseGlow {
+    0% {
+      box-shadow: 0 0 0 0 rgba(255, 123, 84, 0.4);
+    }
+    70% {
+      box-shadow: 0 0 0 20px rgba(255, 123, 84, 0);
+    }
+    100% {
+      box-shadow: 0 0 0 0 rgba(255, 123, 84, 0);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .voiceChat {
+      &__header {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1rem;
+      }
+
+      &__nav {
+        justify-content: space-between;
+      }
+
+      &__titleGroup {
+        justify-content: space-between;
+      }
+
+      &__conversation {
+        padding: 1rem;
+      }
+
+      &__micRow {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      &__micButton {
+        width: 100%;
+        min-width: 0;
+      }
+
+      &__dockButtons {
+        width: 100%;
+        flex-direction: column;
+      }
+
+      &__secondaryButton {
+        width: 100%;
+        text-align: center;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a launch button that routes chat users into a new voice mode view
- build the voice conversation interface with speech recognition fallback, TTS playback, and updated styling
- extend shared helpers and content to support audio roundtrips and localized copy for voice controls

## Testing
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68d60560870483309012afea66cd09c4