### PR TITLE
Revamp chat UI and add continuous voice controls

### DIFF
--- a/client/src/components/Chat/chat.module.scss
+++ b/client/src/components/Chat/chat.module.scss
@@ -1,0 +1,286 @@
+:root {
+  --bg: #000;
+  --fg: #f5f5f5;
+  --muted: #a1a1a1;
+  --accent: #f5a524;
+  --bubble: #111;
+  --bubbleUser: #1a1a1a;
+  --primary: #fff;
+}
+
+.chat {
+  background: var(--bg);
+  color: var(--fg);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  height: 100%;
+}
+
+.header {
+  display: grid;
+  grid-template-columns: 44px 1fr 44px;
+  align-items: center;
+  padding: 1.125rem 1rem 0.75rem;
+  gap: 0.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.92), rgba(0, 0, 0, 0.7));
+  backdrop-filter: blur(12px);
+}
+
+.headerButton {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg);
+  cursor: pointer;
+}
+
+.headerButton:active {
+  transform: scale(0.96);
+}
+
+.title {
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+.statusWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.statusDot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(245, 165, 36, 0.1);
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 1rem 6.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  scroll-behavior: smooth;
+}
+
+.messageRow {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.user {
+  align-items: flex-end;
+}
+
+.assistant {
+  align-items: flex-start;
+}
+
+.bubble {
+  max-width: min(88%, 560px);
+  border-radius: 1.5rem;
+  padding: 0.9rem 1rem 1rem;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  position: relative;
+  background: var(--bubble);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  color: var(--fg);
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.userBubble {
+  background: var(--bubbleUser);
+  border-color: rgba(255, 255, 255, 0.12);
+  color: var(--primary);
+}
+
+.triageLabel {
+  align-self: flex-start;
+  background: rgba(245, 165, 36, 0.18);
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 0.2rem 0.75rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.time {
+  font-size: 0.7rem;
+  color: var(--muted);
+  margin: 0 0.5rem;
+}
+
+.messageActions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.playButton {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--fg);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.playButton:active {
+  transform: scale(0.94);
+}
+
+.composer {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1.25rem 1rem 1.5rem;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.92) 28%, rgba(0, 0, 0, 1) 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 3;
+}
+
+.composerRow {
+  display: grid;
+  grid-template-columns: 52px 1fr 52px 52px;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.roundButton {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.3rem;
+  cursor: pointer;
+}
+
+.roundButton:active {
+  transform: scale(0.95);
+}
+
+.roundButton:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+
+.micActive {
+  background: rgba(245, 165, 36, 0.18);
+  color: var(--accent);
+  border-color: rgba(245, 165, 36, 0.36);
+}
+
+.inputWrapper {
+  position: relative;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.input {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--primary);
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  line-height: 1.4;
+}
+
+.input::placeholder {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.input:focus {
+  outline: none;
+}
+
+.typing {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.typing span {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.6);
+  animation: pulse 1s infinite ease-in-out;
+}
+
+.typing span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.typing span:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes pulse {
+  0%,
+  80%,
+  100% {
+    transform: scale(0.6);
+    opacity: 0.4;
+  }
+
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@media (min-width: 768px) {
+  .chat {
+    border-radius: 28px;
+    max-width: 640px;
+    margin: 0 auto;
+    overflow: hidden;
+  }
+
+  .header {
+    padding: 1.5rem 1.75rem 1rem;
+  }
+
+  .messages {
+    padding: 0 1.75rem 7rem;
+  }
+
+  .composer {
+    padding: 1.5rem 1.75rem 2rem;
+  }
+}

--- a/client/src/components/ChatBox/ChatBox.jsx
+++ b/client/src/components/ChatBox/ChatBox.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useRef, useState } from "react";
-import { FiSend } from "react-icons/fi";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { FiMenu, FiMic, FiMicOff, FiPlay, FiPlus } from "react-icons/fi";
 import { http } from "../../api/http.js";
-import "./chatBox.styles.scss";
 import { useChatMessages } from "../../features/messages/hooks/useChatMessages.js";
+import useVoiceChat from "../../hooks/useVoiceChat.js";
+import styles from "../Chat/chat.module.scss";
 
 const formatTime = (value) => {
   try {
@@ -17,100 +18,261 @@ const formatTime = (value) => {
 
 const genId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
+const WaveIcon = (props) => (
+  <svg
+    aria-hidden="true"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M3 12c2.4 0 2.4-6 4.8-6s2.4 12 4.8 12 2.4-12 4.8-12 2.4 6 4.8 6"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 const ChatBox = ({ daySummary }) => {
   const { messages, appendMessages } = useChatMessages();
   const [input, setInput] = useState("");
   const [isSending, setIsSending] = useState(false);
   const scrollAnchorRef = useRef(null);
   const inputRef = useRef(null);
+  const lastSpokenRef = useRef(null);
+  const voiceQueueRef = useRef([]);
 
-  // Auto-scroll to the latest message
+  const {
+    canListen,
+    canSpeak,
+    isListening,
+    lastTranscript,
+    resetTranscript,
+    speak,
+    startListening,
+    stopListening,
+  } = useVoiceChat();
+
   useEffect(() => {
     scrollAnchorRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages.length, isSending]);
 
-  const handleSubmit = async (event) => {
-    event.preventDefault();
-    inputRef.current?.focus();
-    const text = input.trim();
-    if (!text || isSending) return;
+  const sendMessage = useCallback(
+    async (text, { fromVoice = false } = {}) => {
+      const trimmed = text.trim();
 
-    const userMessage = {
-      id: genId(),
-      role: "user",
-      content: text,
-      timestamp: new Date().toISOString(),
-    };
+      if (!trimmed) {
+        return;
+      }
 
-    await appendMessages(userMessage);
-    setInput("");
-    setIsSending(true);
+      if (isSending) {
+        if (fromVoice) {
+          voiceQueueRef.current.push(trimmed);
+        }
+        return;
+      }
 
-    try {
-      const payload = {
-        text,
-        ...(daySummary
-          ? {
-              dayData: {
-                dayIndex: daySummary.day,
-                babyUpdate: daySummary.babyUpdate,
-                momUpdate: daySummary.momUpdate,
-                tips: daySummary.tips,
-              },
-            }
-          : {}),
+      const userMessage = {
+        id: genId(),
+        role: "user",
+        content: trimmed,
+        timestamp: new Date().toISOString(),
       };
 
-      const data = await http.post("/chat/ask", { json: payload });
-      const assistantContent =
-        data?.content ||
-        data?.message ||
-        "I'm not sure how to respond right now, but I'm here for you.";
+      if (!fromVoice) {
+        setInput("");
+      }
 
-      const assistantMessage = {
-        id: genId(),
-        role: "assistant",
-        content: assistantContent,
-        timestamp: new Date().toISOString(),
-        meta: data?.triage ? { triage: true } : undefined,
-      };
+      await appendMessages(userMessage);
+      setIsSending(true);
 
-      await appendMessages(assistantMessage);
-    } catch (error) {
-      await appendMessages({
-        id: genId(),
-        role: "assistant",
-        content: error?.message || "Failed to send message.",
-        timestamp: new Date().toISOString(),
-      });
-    } finally {
-      setIsSending(false);
+      try {
+        const payload = {
+          text: trimmed,
+          ...(daySummary
+            ? {
+                dayData: {
+                  dayIndex: daySummary.day,
+                  babyUpdate: daySummary.babyUpdate,
+                  momUpdate: daySummary.momUpdate,
+                  tips: daySummary.tips,
+                },
+              }
+            : {}),
+        };
+
+        const data = await http.post("/chat/ask", { json: payload });
+        const assistantContent =
+          data?.content ||
+          data?.message ||
+          "I'm not sure how to respond right now, but I'm here for you.";
+
+        const assistantMessage = {
+          id: genId(),
+          role: "assistant",
+          content: assistantContent,
+          timestamp: new Date().toISOString(),
+          meta: data?.triage ? { triage: true } : undefined,
+        };
+
+        await appendMessages(assistantMessage);
+      } catch (error) {
+        await appendMessages({
+          id: genId(),
+          role: "assistant",
+          content: error?.message || "Failed to send message.",
+          timestamp: new Date().toISOString(),
+        });
+      } finally {
+        setIsSending(false);
+        if (!fromVoice) {
+          inputRef.current?.focus();
+        }
+      }
+    },
+    [appendMessages, daySummary, isSending]
+  );
+
+  const handleSubmit = useCallback(
+    (event) => {
+      event.preventDefault();
       inputRef.current?.focus();
-    }
-  };
+      void sendMessage(input);
+    },
+    [input, sendMessage]
+  );
 
-  const renderMessage = (entry) => {
-    const tone = entry.meta?.triage ? "triage" : entry.role;
-    return (
-      <div key={entry.id} className={`bubble bubble--${tone ?? "assistant"}`}>
-        <div className="body">
-          {entry.meta?.triage && <div className="flag">Important</div>}
-          <p>{entry.content}</p>
+  const toggleMic = useCallback(() => {
+    if (!canListen) {
+      return;
+    }
+
+    if (isListening) {
+      stopListening();
+    } else {
+      startListening();
+    }
+  }, [canListen, isListening, startListening, stopListening]);
+
+  const handleReplay = useCallback(
+    (message) => {
+      if (!message?.content) {
+        return;
+      }
+
+      speak(message.content, { rate: 0.96, pitch: 1, volume: 1 });
+    },
+    [speak]
+  );
+
+  useEffect(() => {
+    if (!lastTranscript) {
+      return;
+    }
+
+    void sendMessage(lastTranscript, { fromVoice: true });
+    resetTranscript();
+  }, [lastTranscript, resetTranscript, sendMessage]);
+
+  useEffect(() => {
+    if (isSending) {
+      return;
+    }
+
+    const nextQueued = voiceQueueRef.current.shift();
+
+    if (nextQueued) {
+      void sendMessage(nextQueued, { fromVoice: true });
+    }
+  }, [isSending, sendMessage]);
+
+  useEffect(() => {
+    if (!messages.length || !canSpeak) {
+      return;
+    }
+
+    const latestAssistant = [...messages]
+      .reverse()
+      .find((message) => message?.role === "assistant" && message?.content);
+
+    if (!latestAssistant) {
+      return;
+    }
+
+    const key = latestAssistant.id || latestAssistant.timestamp || latestAssistant.content;
+
+    if (lastSpokenRef.current === key) {
+      return;
+    }
+
+    lastSpokenRef.current = key;
+    speak(latestAssistant.content, { rate: 0.96, pitch: 1, volume: 1 });
+  }, [messages, speak, canSpeak]);
+
+  useEffect(() => {
+    if (!messages.length) {
+      lastSpokenRef.current = null;
+    }
+  }, [messages.length]);
+
+  const renderMessage = useCallback(
+    (entry, index) => {
+      const isUser = entry?.role === "user";
+      const triage = entry?.meta?.triage;
+      const rowClass = `${styles.messageRow} ${isUser ? styles.user : styles.assistant}`;
+      const bubbleClass = `${styles.bubble} ${isUser ? styles.userBubble : ""}`;
+      const key = entry?.id || entry?.timestamp || index;
+
+      return (
+        <div key={key} className={rowClass}>
+          <div className={bubbleClass}>
+            {triage && <span className={styles.triageLabel}>Important</span>}
+            <div>{entry?.content}</div>
+            {!isUser && (
+              <div className={styles.messageActions}>
+                <button
+                  type="button"
+                  className={styles.playButton}
+                  onClick={() => handleReplay(entry)}
+                  aria-label="Replay response"
+                  disabled={!canSpeak}
+                >
+                  <FiPlay aria-hidden="true" size={18} />
+                </button>
+              </div>
+            )}
+          </div>
+          <time className={styles.time}>{formatTime(entry?.timestamp)}</time>
         </div>
-        <time className="time">{formatTime(entry.timestamp)}</time>
-      </div>
-    );
-  };
+      );
+    },
+    [canSpeak, handleReplay]
+  );
 
   return (
-    <div className="container dark">
-      <main className="messages">
+    <div className={styles.chat}>
+      <header className={styles.header}>
+        <button type="button" className={styles.headerButton} aria-label="Open menu">
+          <FiMenu aria-hidden="true" size={20} />
+        </button>
+        <h1 className={styles.title}>ChatGPT 5</h1>
+        <div className={styles.statusWrapper} aria-label="Online">
+          <span className={styles.statusDot} />
+        </div>
+      </header>
+
+      <main className={styles.messages}>
         {messages.map(renderMessage)}
 
         {isSending && (
-          <div className="bubble bubble--assistant">
-            <div className="body">
-              <div className="typing">
+          <div className={`${styles.messageRow} ${styles.assistant}`}>
+            <div className={styles.bubble}>
+              <div className={styles.typing}>
                 <span />
                 <span />
                 <span />
@@ -122,29 +284,48 @@ const ChatBox = ({ daySummary }) => {
         <div ref={scrollAnchorRef} />
       </main>
 
-      <form className="composer" onSubmit={handleSubmit}>
-        <div className="wrap">
-          <div className="field">
+      <form className={styles.composer} onSubmit={handleSubmit}>
+        <div className={styles.composerRow}>
+          <button type="button" className={styles.roundButton} aria-label="Add prompt">
+            <FiPlus aria-hidden="true" size={22} />
+          </button>
+
+          <div className={styles.inputWrapper}>
             <input
-              className="input"
+              ref={inputRef}
+              className={styles.input}
               type="text"
               value={input}
-              onChange={(e) => setInput(e.target.value)}
-              placeholder="Ask Aya about your pregnancy..."
+              onChange={(event) => setInput(event.target.value)}
+              placeholder="Ask anything"
               disabled={isSending}
-              ref={inputRef}
               autoFocus
             />
-            <button
-              className="send"
-              type="submit"
-              aria-label="Send message"
-              title="Send message"
-              disabled={!input.trim() || isSending}
-            >
-              <FiSend aria-hidden="true" size={20} />
-            </button>
           </div>
+
+          <button
+            type="button"
+            className={`${styles.roundButton} ${isListening ? styles.micActive : ""}`}
+            onClick={toggleMic}
+            aria-pressed={isListening}
+            aria-label={isListening ? "Stop voice input" : "Start voice input"}
+            disabled={!canListen}
+          >
+            {isListening ? (
+              <FiMicOff aria-hidden="true" size={22} />
+            ) : (
+              <FiMic aria-hidden="true" size={22} />
+            )}
+          </button>
+
+          <button
+            className={styles.roundButton}
+            type="submit"
+            aria-label="Send message"
+            disabled={!input.trim() || isSending}
+          >
+            <WaveIcon />
+          </button>
         </div>
       </form>
     </div>

--- a/client/src/hooks/useVoiceChat.js
+++ b/client/src/hooks/useVoiceChat.js
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const getSpeechRecognition = () => {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  return window.SpeechRecognition || window.webkitSpeechRecognition;
+};
+
+const useVoiceChat = () => {
+  const Recognition = useMemo(() => getSpeechRecognition(), []);
+  const recognitionRef = useRef(null);
+  const isExpectedStopRef = useRef(false);
+  const shouldBeListeningRef = useRef(false);
+  const restartTimeoutRef = useRef(null);
+  const [isListening, setIsListening] = useState(false);
+  const [lastTranscript, setLastTranscript] = useState("");
+
+  const canListen = Boolean(Recognition);
+  const canSpeak = typeof window !== "undefined" && "speechSynthesis" in window;
+
+  const clearRestartTimeout = useCallback(() => {
+    if (restartTimeoutRef.current) {
+      clearTimeout(restartTimeoutRef.current);
+      restartTimeoutRef.current = null;
+    }
+  }, []);
+
+  const resetTranscript = useCallback(() => {
+    setLastTranscript("");
+  }, []);
+
+  const stopListening = useCallback(() => {
+    isExpectedStopRef.current = true;
+    shouldBeListeningRef.current = false;
+    clearRestartTimeout();
+    setIsListening(false);
+
+    if (recognitionRef.current) {
+      try {
+        recognitionRef.current.stop();
+      } catch (error) {
+        // Some browsers throw if stop is called while inactive; ignore.
+      }
+    }
+  }, [clearRestartTimeout]);
+
+  const handleResult = useCallback((event) => {
+    if (!event.results) {
+      return;
+    }
+
+    let transcript = "";
+
+    for (let index = event.resultIndex; index < event.results.length; index += 1) {
+      const result = event.results[index];
+      if (result.isFinal && result[0] && result[0].transcript) {
+        transcript = `${transcript} ${result[0].transcript}`.trim();
+      }
+    }
+
+    if (transcript) {
+      setLastTranscript(transcript);
+    }
+  }, []);
+
+  const ensureRecognition = useCallback(() => {
+    if (!Recognition) {
+      return null;
+    }
+
+    if (!recognitionRef.current) {
+      const instance = new Recognition();
+      instance.continuous = true;
+      instance.interimResults = false;
+      instance.lang = window?.navigator?.language || "en-US";
+
+      instance.onresult = handleResult;
+      instance.onstart = () => {
+        setIsListening(true);
+        isExpectedStopRef.current = false;
+      };
+
+      instance.onend = () => {
+        setIsListening(false);
+
+        if (isExpectedStopRef.current || !shouldBeListeningRef.current) {
+          isExpectedStopRef.current = false;
+          return;
+        }
+
+        // iOS Safari often stops unexpectedly; restart to keep continuous mode alive.
+        clearRestartTimeout();
+        restartTimeoutRef.current = setTimeout(() => {
+          try {
+            instance.start();
+          } catch (error) {
+            // Restart may fail if the microphone is busy; ignore and wait for next opportunity.
+          }
+        }, 400);
+      };
+
+      instance.onerror = (event) => {
+        if (event.error === "not-allowed" || event.error === "service-not-allowed") {
+          shouldBeListeningRef.current = false;
+          isExpectedStopRef.current = true;
+        }
+      };
+
+      recognitionRef.current = instance;
+    }
+
+    return recognitionRef.current;
+  }, [Recognition, clearRestartTimeout, handleResult]);
+
+  const startListening = useCallback(() => {
+    if (!Recognition) {
+      return;
+    }
+
+    const recognition = ensureRecognition();
+
+    if (!recognition) {
+      return;
+    }
+
+    shouldBeListeningRef.current = true;
+    isExpectedStopRef.current = false;
+
+    try {
+      recognition.start();
+    } catch (error) {
+      // Restart if already active.
+      try {
+        recognition.stop();
+        recognition.start();
+      } catch (retryError) {
+        // Ignore if retry fails; browser may still be starting.
+      }
+    }
+  }, [Recognition, ensureRecognition]);
+
+  const speak = useCallback((text, options = {}) => {
+    if (!canSpeak || !text) {
+      return undefined;
+    }
+
+    window.speechSynthesis.cancel();
+    const utterance = new SpeechSynthesisUtterance(text);
+
+    if (options.pitch) {
+      utterance.pitch = options.pitch;
+    }
+
+    if (options.rate) {
+      utterance.rate = options.rate;
+    }
+
+    if (options.volume !== undefined) {
+      utterance.volume = options.volume;
+    }
+
+    if (options.voice) {
+      utterance.voice = options.voice;
+    }
+
+    window.speechSynthesis.speak(utterance);
+    return utterance;
+  }, [canSpeak]);
+
+  useEffect(() => () => {
+    stopListening();
+    if (canSpeak) {
+      window.speechSynthesis.cancel();
+    }
+  }, [stopListening, canSpeak]);
+
+  return {
+    canListen,
+    canSpeak,
+    isListening,
+    lastTranscript,
+    resetTranscript,
+    speak,
+    startListening,
+    stopListening,
+  };
+};
+
+export default useVoiceChat;


### PR DESCRIPTION
## Summary
- redesign the chat screen to match the ChatGPT 5 dark layout with header, composer, and improved message bubbles
- add a reusable `useVoiceChat` hook that provides continuous speech recognition and speech synthesis playback
- style the new experience with a dedicated SCSS module including touch-friendly controls and replay buttons

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d6195a72ac8330bf7abdb8f089dc88