### PR TITLE
Add voice barge-in and indicators to chat

### DIFF
--- a/client/src/components/Chat/chat.module.scss
+++ b/client/src/components/Chat/chat.module.scss
@@ -14,33 +14,33 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  height: 100%;
+  width: 100%;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 .header {
-  display: grid;
-  grid-template-columns: 44px 1fr 44px;
+  display: flex;
   align-items: center;
-  padding: 1.125rem 1rem 0.75rem;
-  gap: 0.5rem;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
   position: sticky;
   top: 0;
-  z-index: 2;
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0.92), rgba(0, 0, 0, 0.7));
+  z-index: 10;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0));
   backdrop-filter: blur(12px);
 }
 
 .headerButton {
-  width: 44px;
-  height: 44px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.04);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--fg);
-  cursor: pointer;
+  appearance: none;
+  border: none;
+  background: rgba(255, 255, 255, 0.06);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.65rem;
+  display: grid;
+  place-items: center;
+  transition: transform 150ms ease, background 150ms ease;
 }
 
 .headerButton:active {
@@ -50,21 +50,33 @@
 .title {
   font-size: 1rem;
   font-weight: 600;
+  flex: 1;
   text-align: center;
 }
 
 .statusWrapper {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: center;
 }
 
 .statusDot {
-  width: 12px;
-  height: 12px;
+  width: 0.7rem;
+  height: 0.7rem;
   border-radius: 50%;
+  background: var(--primary);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.25);
+  transition: background 150ms ease, box-shadow 150ms ease;
+}
+
+.statusDotListening {
   background: var(--accent);
-  box-shadow: 0 0 0 4px rgba(245, 165, 36, 0.1);
+  box-shadow: 0 0 0 4px rgba(245, 165, 36, 0.2);
+}
+
+.statusDotSpeaking {
+  background: #22c55e;
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.2);
 }
 
 .messages {
@@ -74,163 +86,92 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  scroll-behavior: smooth;
 }
 
 .messageRow {
   display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-
-.user {
   align-items: flex-end;
+  gap: 0.75rem;
 }
 
 .assistant {
-  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+.user {
+  justify-content: flex-end;
 }
 
 .bubble {
-  max-width: min(88%, 560px);
-  border-radius: 1.5rem;
-  padding: 0.9rem 1rem 1rem;
-  font-size: 0.95rem;
-  line-height: 1.45;
-  position: relative;
   background: var(--bubble);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  color: var(--fg);
-  display: inline-flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  padding: 0.875rem 1rem;
+  border-radius: 1.25rem;
+  max-width: min(80vw, 34rem);
+  line-height: 1.45;
+  font-size: 0.95rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 }
 
 .userBubble {
   background: var(--bubbleUser);
-  border-color: rgba(255, 255, 255, 0.12);
-  color: var(--primary);
+  border-bottom-right-radius: 0.4rem;
 }
 
 .triageLabel {
-  align-self: flex-start;
-  background: rgba(245, 165, 36, 0.18);
-  color: var(--accent);
-  border-radius: 999px;
-  padding: 0.2rem 0.75rem;
-  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
   font-weight: 600;
-  letter-spacing: 0.04em;
   text-transform: uppercase;
-}
-
-.time {
-  font-size: 0.7rem;
-  color: var(--muted);
-  margin: 0 0.5rem;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  margin-bottom: 0.35rem;
 }
 
 .messageActions {
+  margin-top: 0.75rem;
   display: flex;
-  align-items: center;
   gap: 0.5rem;
+  justify-content: flex-end;
 }
 
 .playButton {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--fg);
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  padding: 0.35rem 0.55rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  cursor: pointer;
+  transition: background 150ms ease, transform 150ms ease;
 }
 
-.playButton:active {
+.playButton:hover:not(:disabled),
+.playButton:focus-visible:not(:disabled) {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.playButton:active:not(:disabled) {
   transform: scale(0.94);
 }
 
-.composer {
-  position: sticky;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 1.25rem 1rem 1.5rem;
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.92) 28%, rgba(0, 0, 0, 1) 100%);
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  z-index: 3;
-}
-
-.composerRow {
-  display: grid;
-  grid-template-columns: 52px 1fr 52px 52px;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.roundButton {
-  width: 52px;
-  height: 52px;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--primary);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.3rem;
-  cursor: pointer;
-}
-
-.roundButton:active {
-  transform: scale(0.95);
-}
-
-.roundButton:disabled {
-  opacity: 0.38;
+.playButton:disabled {
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
-.micActive {
-  background: rgba(245, 165, 36, 0.18);
-  color: var(--accent);
-  border-color: rgba(245, 165, 36, 0.36);
-}
-
-.inputWrapper {
-  position: relative;
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  overflow: hidden;
-}
-
-.input {
-  width: 100%;
-  border: none;
-  background: transparent;
-  color: var(--primary);
-  padding: 0.85rem 1rem;
-  font-size: 1rem;
-  line-height: 1.4;
-}
-
-.input::placeholder {
-  color: rgba(255, 255, 255, 0.45);
-}
-
-.input:focus {
-  outline: none;
+.time {
+  font-size: 0.75rem;
+  color: var(--muted);
+  min-width: 3.25rem;
+  text-align: right;
 }
 
 .typing {
   display: inline-flex;
-  align-items: center;
   gap: 0.3rem;
 }
 
@@ -239,48 +180,230 @@
   height: 0.45rem;
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.6);
-  animation: pulse 1s infinite ease-in-out;
+  animation: typing 1.2s infinite ease-in-out;
 }
 
 .typing span:nth-child(2) {
-  animation-delay: 0.2s;
+  animation-delay: 0.15s;
 }
 
 .typing span:nth-child(3) {
-  animation-delay: 0.4s;
+  animation-delay: 0.3s;
 }
 
-@keyframes pulse {
+@keyframes typing {
   0%,
   80%,
   100% {
-    transform: scale(0.6);
-    opacity: 0.4;
+    opacity: 0.3;
+    transform: translateY(0);
   }
-
   40% {
-    transform: scale(1);
     opacity: 1;
+    transform: translateY(-0.25rem);
   }
 }
 
-@media (min-width: 768px) {
-  .chat {
-    border-radius: 28px;
-    max-width: 640px;
-    margin: 0 auto;
-    overflow: hidden;
-  }
+.composerShell {
+  position: sticky;
+  bottom: 0;
+  padding: 1.25rem 1rem 1.5rem;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.9) 35%, #000 100%);
+}
 
+.listeningChip {
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -110%);
+  background: rgba(245, 165, 36, 0.12);
+  color: var(--accent);
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  box-shadow: 0 0 0 1px rgba(245, 165, 36, 0.25);
+  animation: chipPulse 1.6s infinite ease-in-out;
+}
+
+.listeningGlow {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(245, 165, 36, 0.25);
+}
+
+@keyframes chipPulse {
+  0%,
+  100% {
+    opacity: 0.8;
+    transform: translate(-50%, -110%) scale(0.98);
+  }
+  50% {
+    opacity: 1;
+    transform: translate(-50%, -110%) scale(1.02);
+  }
+}
+
+.composer {
+  margin: 0 auto;
+  max-width: 48rem;
+  background: rgba(17, 17, 17, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.5rem;
+  padding: 0.75rem;
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.45);
+}
+
+.composerRow {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.inputWrapper {
+  flex: 1;
+  min-width: 0;
+}
+
+.input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--fg);
+  font-size: 1rem;
+  padding: 0.4rem 0.2rem;
+  outline: none;
+}
+
+.roundButton {
+  appearance: none;
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--primary);
+  border-radius: 999px;
+  width: 3rem;
+  height: 3rem;
+  min-width: 3rem;
+  min-height: 3rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 150ms ease, background 150ms ease, box-shadow 150ms ease;
+}
+
+.roundButton:active {
+  transform: scale(0.94);
+}
+
+.micActive {
+  background: rgba(245, 165, 36, 0.2);
+  box-shadow: 0 0 0 6px rgba(245, 165, 36, 0.15);
+  color: var(--accent);
+}
+
+.micInterrupt {
+  background: rgba(34, 197, 94, 0.2);
+  color: #22c55e;
+  box-shadow: 0 0 0 6px rgba(34, 197, 94, 0.18);
+}
+
+.roundButton:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.notice {
+  margin-top: 0.5rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: rgba(245, 165, 36, 0.9);
+}
+
+.speakingIndicator {
+  margin-top: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #22c55e;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.speakingWave {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 0.2rem;
+}
+
+.speakingWave span {
+  width: 0.2rem;
+  border-radius: 0.3rem;
+  background: currentColor;
+  animation: equalize 1.1s ease-in-out infinite;
+}
+
+.speakingWave span:nth-child(1) {
+  height: 0.45rem;
+}
+
+.speakingWave span:nth-child(2) {
+  height: 0.8rem;
+  animation-delay: 0.15s;
+}
+
+.speakingWave span:nth-child(3) {
+  height: 0.6rem;
+  animation-delay: 0.3s;
+}
+
+@keyframes equalize {
+  0%,
+  100% {
+    transform: scaleY(0.6);
+  }
+  50% {
+    transform: scaleY(1.1);
+  }
+}
+
+.liveRegion {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  border: 0;
+}
+
+@media (max-width: 600px) {
   .header {
-    padding: 1.5rem 1.75rem 1rem;
+    padding: 0.85rem 1rem;
   }
 
-  .messages {
-    padding: 0 1.75rem 7rem;
+  .composerShell {
+    padding: 1rem 0.75rem 1.25rem;
   }
 
   .composer {
-    padding: 1.5rem 1.75rem 2rem;
+    padding: 0.65rem;
+    border-radius: 1.25rem;
+  }
+
+  .roundButton {
+    width: 2.8rem;
+    height: 2.8rem;
+    min-width: 2.8rem;
+    min-height: 2.8rem;
+  }
+
+  .bubble {
+    max-width: 84vw;
   }
 }

--- a/client/src/components/ChatBox/ChatBox.jsx
+++ b/client/src/components/ChatBox/ChatBox.jsx
@@ -1,9 +1,17 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FiMenu, FiMic, FiMicOff, FiPlay, FiPlus } from "react-icons/fi";
 import { http } from "../../api/http.js";
 import { useChatMessages } from "../../features/messages/hooks/useChatMessages.js";
 import useVoiceChat from "../../hooks/useVoiceChat.js";
 import styles from "../Chat/chat.module.scss";
+
+const UI_STATES = {
+  idle: "idle",
+  listening: "listening",
+  sending: "sending",
+  speaking: "speaking",
+  interrupting: "interrupting",
+};
 
 const formatTime = (value) => {
   try {
@@ -42,25 +50,134 @@ const ChatBox = ({ daySummary }) => {
   const { messages, appendMessages } = useChatMessages();
   const [input, setInput] = useState("");
   const [isSending, setIsSending] = useState(false);
+  const [uiState, setUiState] = useState(UI_STATES.idle);
+  const [speaking, setSpeaking] = useState(false);
+  const [speakingMessageId, setSpeakingMessageId] = useState(null);
+  const [voiceNotice, setVoiceNotice] = useState(null);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const scrollAnchorRef = useRef(null);
   const inputRef = useRef(null);
   const lastSpokenRef = useRef(null);
   const voiceQueueRef = useRef([]);
+  const abortControllerRef = useRef(null);
+  const requestIdRef = useRef(0);
+  const currentRequestIdRef = useRef(0);
+  const liveRegionRef = useRef(null);
+  const activeUtteranceRef = useRef(null);
 
   const {
-    canListen,
-    canSpeak,
-    isListening,
-    lastTranscript,
-    resetTranscript,
-    speak,
+    canUseVoice,
+    listening,
     startListening,
     stopListening,
+    speak,
+    lastTranscript,
+    resetTranscript,
+    supportsFullDuplex,
+    voiceError,
   } = useVoiceChat();
 
-  useEffect(() => {
-    scrollAnchorRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages.length, isSending]);
+  const statusIsSpeaking = speaking || isSending;
+  const statusDotClass = `${styles.statusDot} ${
+    statusIsSpeaking ? styles.statusDotSpeaking : listening ? styles.statusDotListening : ""
+  }`;
+  const statusLabel = statusIsSpeaking ? "Assistant speaking" : listening ? "Listening" : "Idle";
+
+  const micLabel = statusIsSpeaking
+    ? "Tap to interrupt"
+    : listening
+    ? "Stop voice input"
+    : "Start voice input";
+
+  const micClasses = useMemo(() => {
+    const classNames = [styles.roundButton];
+
+    if (listening) {
+      classNames.push(styles.micActive);
+    }
+
+    if (statusIsSpeaking) {
+      classNames.push(styles.micInterrupt);
+    }
+
+    return classNames.join(" ");
+  }, [listening, statusIsSpeaking]);
+
+  const queueAnimationFrame = useCallback((callback) => {
+    if (typeof window === "undefined") {
+      callback();
+      return;
+    }
+
+    const raf = window.requestAnimationFrame || window.setTimeout;
+    raf(() => callback());
+  }, []);
+
+  const announce = useCallback(
+    (message) => {
+      if (!liveRegionRef.current) {
+        return;
+      }
+
+      liveRegionRef.current.textContent = "";
+      queueAnimationFrame(() => {
+        if (liveRegionRef.current) {
+          liveRegionRef.current.textContent = message;
+        }
+      });
+    },
+    [queueAnimationFrame]
+  );
+
+  const vibrate = useCallback(() => {
+    if (prefersReducedMotion) {
+      return;
+    }
+
+    if (typeof navigator !== "undefined" && navigator.vibrate) {
+      navigator.vibrate(20);
+    }
+  }, [prefersReducedMotion]);
+
+  const handleInterrupt = useCallback(
+    ({ resumeListening = false, announceInterrupt = true } = {}) => {
+      let didInterrupt = false;
+
+      setUiState(UI_STATES.interrupting);
+
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+        abortControllerRef.current = null;
+        didInterrupt = true;
+      }
+
+      if (typeof window !== "undefined" && window.speechSynthesis) {
+        window.speechSynthesis.cancel();
+        didInterrupt = true;
+      }
+
+      if (activeUtteranceRef.current) {
+        activeUtteranceRef.current = null;
+      }
+
+      if (didInterrupt && announceInterrupt) {
+        announce("Interrupted");
+        vibrate();
+      }
+
+      setSpeaking(false);
+      setSpeakingMessageId(null);
+      setIsSending(false);
+
+      if (resumeListening) {
+        setUiState(UI_STATES.listening);
+        startListening();
+      } else if (!listening) {
+        setUiState(UI_STATES.idle);
+      }
+    },
+    [announce, vibrate, listening, startListening]
+  );
 
   const sendMessage = useCallback(
     async (text, { fromVoice = false } = {}) => {
@@ -90,6 +207,19 @@ const ChatBox = ({ daySummary }) => {
 
       await appendMessages(userMessage);
       setIsSending(true);
+      setVoiceNotice(null);
+      setUiState(UI_STATES.sending);
+
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+
+      const nextRequestId = requestIdRef.current + 1;
+      requestIdRef.current = nextRequestId;
+      currentRequestIdRef.current = nextRequestId;
 
       try {
         const payload = {
@@ -106,7 +236,12 @@ const ChatBox = ({ daySummary }) => {
             : {}),
         };
 
-        const data = await http.post("/chat/ask", { json: payload });
+        const data = await http.post("/chat/ask", { json: payload, signal: abortController.signal });
+
+        if (nextRequestId !== currentRequestIdRef.current) {
+          return;
+        }
+
         const assistantContent =
           data?.content ||
           data?.message ||
@@ -122,6 +257,10 @@ const ChatBox = ({ daySummary }) => {
 
         await appendMessages(assistantMessage);
       } catch (error) {
+        if (error.name === "AbortError") {
+          return;
+        }
+
         await appendMessages({
           id: genId(),
           role: "assistant",
@@ -129,13 +268,22 @@ const ChatBox = ({ daySummary }) => {
           timestamp: new Date().toISOString(),
         });
       } finally {
-        setIsSending(false);
-        if (!fromVoice) {
-          inputRef.current?.focus();
+        if (nextRequestId === currentRequestIdRef.current) {
+          setIsSending(false);
+          abortControllerRef.current = null;
+          if (!fromVoice) {
+            inputRef.current?.focus();
+          }
+
+          if (listening) {
+            setUiState(UI_STATES.listening);
+          } else if (!speaking) {
+            setUiState(UI_STATES.idle);
+          }
         }
       }
     },
-    [appendMessages, daySummary, isSending]
+    [appendMessages, daySummary, isSending, listening, speaking]
   );
 
   const handleSubmit = useCallback(
@@ -147,37 +295,102 @@ const ChatBox = ({ daySummary }) => {
     [input, sendMessage]
   );
 
-  const toggleMic = useCallback(() => {
-    if (!canListen) {
-      return;
-    }
-
-    if (isListening) {
-      stopListening();
-    } else {
-      startListening();
-    }
-  }, [canListen, isListening, startListening, stopListening]);
-
   const handleReplay = useCallback(
     (message) => {
       if (!message?.content) {
         return;
       }
 
-      speak(message.content, { rate: 0.96, pitch: 1, volume: 1 });
+      speak(message.content, {
+        rate: 0.96,
+        pitch: 1,
+        volume: 1,
+        onStart: () => {
+          setSpeaking(true);
+          setSpeakingMessageId(message.id || message.timestamp || message.content);
+          if (!supportsFullDuplex) {
+            stopListening();
+          }
+        },
+        onEnd: () => {
+          setSpeaking(false);
+          setSpeakingMessageId(null);
+          if (!supportsFullDuplex) {
+            startListening();
+          }
+        },
+      });
     },
-    [speak]
+    [speak, startListening, stopListening, supportsFullDuplex]
   );
+
+  const handleMicPress = useCallback(() => {
+    if (!canUseVoice) {
+      return;
+    }
+
+    if (statusIsSpeaking) {
+      handleInterrupt({ resumeListening: true });
+      return;
+    }
+
+    if (listening) {
+      stopListening();
+      setUiState(UI_STATES.idle);
+    } else {
+      setUiState(UI_STATES.listening);
+      startListening();
+    }
+  }, [canUseVoice, handleInterrupt, listening, startListening, statusIsSpeaking, stopListening]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handleChange = (event) => setPrefersReducedMotion(event.matches);
+
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener("change", handleChange);
+    } else {
+      mediaQuery.addListener(handleChange);
+    }
+
+    return () => {
+      if (mediaQuery.removeEventListener) {
+        mediaQuery.removeEventListener("change", handleChange);
+      } else {
+        mediaQuery.removeListener(handleChange);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    scrollAnchorRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages.length, isSending]);
 
   useEffect(() => {
     if (!lastTranscript) {
       return;
     }
 
-    void sendMessage(lastTranscript, { fromVoice: true });
+    const trimmed = lastTranscript.trim();
+
+    if (!trimmed) {
+      resetTranscript();
+      return;
+    }
+
+    if (statusIsSpeaking) {
+      handleInterrupt({ resumeListening: false });
+    }
+
+    void sendMessage(trimmed, { fromVoice: true });
     resetTranscript();
-  }, [lastTranscript, resetTranscript, sendMessage]);
+  }, [handleInterrupt, lastTranscript, resetTranscript, sendMessage, statusIsSpeaking]);
 
   useEffect(() => {
     if (isSending) {
@@ -192,7 +405,7 @@ const ChatBox = ({ daySummary }) => {
   }, [isSending, sendMessage]);
 
   useEffect(() => {
-    if (!messages.length || !canSpeak) {
+    if (!messages.length || !canUseVoice) {
       return;
     }
 
@@ -204,15 +417,34 @@ const ChatBox = ({ daySummary }) => {
       return;
     }
 
-    const key = latestAssistant.id || latestAssistant.timestamp || latestAssistant.content;
+    const messageKey = latestAssistant.id || latestAssistant.timestamp || latestAssistant.content;
 
-    if (lastSpokenRef.current === key) {
+    if (lastSpokenRef.current === messageKey) {
       return;
     }
 
-    lastSpokenRef.current = key;
-    speak(latestAssistant.content, { rate: 0.96, pitch: 1, volume: 1 });
-  }, [messages, speak, canSpeak]);
+    lastSpokenRef.current = messageKey;
+
+    activeUtteranceRef.current = speak(latestAssistant.content, {
+      rate: 0.96,
+      pitch: 1,
+      volume: 1,
+      onStart: () => {
+        setSpeaking(true);
+        setSpeakingMessageId(messageKey);
+        if (!supportsFullDuplex) {
+          stopListening();
+        }
+      },
+      onEnd: () => {
+        setSpeaking(false);
+        setSpeakingMessageId(null);
+        if (!supportsFullDuplex) {
+          startListening();
+        }
+      },
+    });
+  }, [canUseVoice, messages, speak, startListening, stopListening, supportsFullDuplex]);
 
   useEffect(() => {
     if (!messages.length) {
@@ -220,38 +452,84 @@ const ChatBox = ({ daySummary }) => {
     }
   }, [messages.length]);
 
+  useEffect(() => {
+    if (!voiceError) {
+      return;
+    }
+
+    setVoiceNotice(voiceError);
+    setUiState((previous) => (previous === UI_STATES.listening ? UI_STATES.idle : previous));
+  }, [voiceError]);
+
+  useEffect(() => {
+    if (listening) {
+      setVoiceNotice(null);
+      setUiState((previous) =>
+        previous === UI_STATES.sending || previous === UI_STATES.speaking
+          ? previous
+          : UI_STATES.listening
+      );
+      announce("Listening started");
+      vibrate();
+    } else if (uiState === UI_STATES.listening) {
+      setUiState(speaking ? UI_STATES.speaking : UI_STATES.idle);
+      announce("Listening stopped");
+    }
+  }, [announce, listening, speaking, uiState, vibrate]);
+
+  useEffect(() => {
+    if (speaking) {
+      setUiState(UI_STATES.speaking);
+      announce("Speaking…");
+    } else if (!listening && !isSending) {
+      setUiState(UI_STATES.idle);
+    }
+  }, [announce, isSending, listening, speaking]);
+
   const renderMessage = useCallback(
     (entry, index) => {
       const isUser = entry?.role === "user";
       const triage = entry?.meta?.triage;
+      const messageId = entry?.id || entry?.timestamp || index;
       const rowClass = `${styles.messageRow} ${isUser ? styles.user : styles.assistant}`;
       const bubbleClass = `${styles.bubble} ${isUser ? styles.userBubble : ""}`;
-      const key = entry?.id || entry?.timestamp || index;
 
       return (
-        <div key={key} className={rowClass}>
+        <div key={messageId} className={rowClass}>
           <div className={bubbleClass}>
             {triage && <span className={styles.triageLabel}>Important</span>}
             <div>{entry?.content}</div>
             {!isUser && (
-              <div className={styles.messageActions}>
-                <button
-                  type="button"
-                  className={styles.playButton}
-                  onClick={() => handleReplay(entry)}
-                  aria-label="Replay response"
-                  disabled={!canSpeak}
-                >
-                  <FiPlay aria-hidden="true" size={18} />
-                </button>
-              </div>
+              <>
+                <div className={styles.messageActions}>
+                  <button
+                    type="button"
+                    className={styles.playButton}
+                    onClick={() => handleReplay(entry)}
+                    aria-label="Replay response"
+                    disabled={!canUseVoice}
+                  >
+                    <FiPlay aria-hidden="true" size={18} />
+                  </button>
+                </div>
+                {speaking && speakingMessageId === messageId && (
+                  <div className={styles.speakingIndicator} aria-label="Assistant is speaking">
+                    <span className={styles.speakingWave} aria-hidden="true">
+                      <span />
+                      <span />
+                      <span />
+                    </span>
+                    <span>Speaking…</span>
+                  </div>
+                )}
+              </>
             )}
           </div>
           <time className={styles.time}>{formatTime(entry?.timestamp)}</time>
         </div>
       );
     },
-    [canSpeak, handleReplay]
+    [canUseVoice, handleReplay, speaking, speakingMessageId]
   );
 
   return (
@@ -261,8 +539,8 @@ const ChatBox = ({ daySummary }) => {
           <FiMenu aria-hidden="true" size={20} />
         </button>
         <h1 className={styles.title}>ChatGPT 5</h1>
-        <div className={styles.statusWrapper} aria-label="Online">
-          <span className={styles.statusDot} />
+        <div className={styles.statusWrapper} aria-label={statusLabel} role="status">
+          <span className={statusDotClass} />
         </div>
       </header>
 
@@ -284,50 +562,67 @@ const ChatBox = ({ daySummary }) => {
         <div ref={scrollAnchorRef} />
       </main>
 
-      <form className={styles.composer} onSubmit={handleSubmit}>
-        <div className={styles.composerRow}>
-          <button type="button" className={styles.roundButton} aria-label="Add prompt">
-            <FiPlus aria-hidden="true" size={22} />
-          </button>
-
-          <div className={styles.inputWrapper}>
-            <input
-              ref={inputRef}
-              className={styles.input}
-              type="text"
-              value={input}
-              onChange={(event) => setInput(event.target.value)}
-              placeholder="Ask anything"
-              disabled={isSending}
-              autoFocus
-            />
+      <div className={styles.composerShell}>
+        {listening && (
+          <div className={styles.listeningChip} role="status" aria-live="polite">
+            <span className={styles.listeningGlow} aria-hidden="true" />
+            Listening…
           </div>
+        )}
 
-          <button
-            type="button"
-            className={`${styles.roundButton} ${isListening ? styles.micActive : ""}`}
-            onClick={toggleMic}
-            aria-pressed={isListening}
-            aria-label={isListening ? "Stop voice input" : "Start voice input"}
-            disabled={!canListen}
-          >
-            {isListening ? (
-              <FiMicOff aria-hidden="true" size={22} />
-            ) : (
-              <FiMic aria-hidden="true" size={22} />
-            )}
-          </button>
+        <form className={styles.composer} onSubmit={handleSubmit}>
+          <div className={styles.composerRow}>
+            <button type="button" className={styles.roundButton} aria-label="Add prompt">
+              <FiPlus aria-hidden="true" size={22} />
+            </button>
 
-          <button
-            className={styles.roundButton}
-            type="submit"
-            aria-label="Send message"
-            disabled={!input.trim() || isSending}
-          >
-            <WaveIcon />
-          </button>
-        </div>
-      </form>
+            <div className={styles.inputWrapper}>
+              <input
+                ref={inputRef}
+                className={styles.input}
+                type="text"
+                value={input}
+                onChange={(event) => setInput(event.target.value)}
+                placeholder="Ask anything"
+                disabled={isSending}
+                autoFocus
+              />
+            </div>
+
+            <button
+              type="button"
+              className={micClasses}
+              onClick={handleMicPress}
+              aria-pressed={listening}
+              aria-label={micLabel}
+              disabled={!canUseVoice}
+            >
+              {listening || statusIsSpeaking ? (
+                <FiMicOff aria-hidden="true" size={22} />
+              ) : (
+                <FiMic aria-hidden="true" size={22} />
+              )}
+            </button>
+
+            <button
+              className={styles.roundButton}
+              type="submit"
+              aria-label="Send message"
+              disabled={!input.trim() || isSending}
+            >
+              <WaveIcon />
+            </button>
+          </div>
+        </form>
+
+        {voiceNotice && (
+          <div className={styles.notice} role="status" aria-live="polite">
+            {voiceNotice}
+          </div>
+        )}
+      </div>
+
+      <span className={styles.liveRegion} ref={liveRegionRef} aria-live="polite" aria-atomic="true" />
     </div>
   );
 };

--- a/client/src/hooks/useVoiceChat.js
+++ b/client/src/hooks/useVoiceChat.js
@@ -8,17 +8,41 @@ const getSpeechRecognition = () => {
   return window.SpeechRecognition || window.webkitSpeechRecognition;
 };
 
+const detectFullDuplexSupport = () => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const userAgent = window.navigator?.userAgent || "";
+  const isIOS = /iP(ad|hone|od)/i.test(userAgent);
+  const isSafari = /Safari/i.test(userAgent) && !/Chrome|CriOS|Android/i.test(userAgent);
+
+  return !(isIOS || isSafari);
+};
+
+const ERROR_MESSAGES = {
+  "no-speech": "No speech detected.",
+  "audio-capture": "Microphone not available.",
+  "not-allowed": "Microphone permission denied.",
+  "service-not-allowed": "Microphone permission denied.",
+};
+
 const useVoiceChat = () => {
   const Recognition = useMemo(() => getSpeechRecognition(), []);
   const recognitionRef = useRef(null);
-  const isExpectedStopRef = useRef(false);
-  const shouldBeListeningRef = useRef(false);
+  const shouldResumeRef = useRef(false);
+  const expectedStopRef = useRef(false);
   const restartTimeoutRef = useRef(null);
-  const [isListening, setIsListening] = useState(false);
+  const [listening, setListening] = useState(false);
   const [lastTranscript, setLastTranscript] = useState("");
+  const [voiceError, setVoiceError] = useState(null);
 
-  const canListen = Boolean(Recognition);
-  const canSpeak = typeof window !== "undefined" && "speechSynthesis" in window;
+  const supportsFullDuplex = useMemo(() => detectFullDuplexSupport(), []);
+  const canUseVoice = Boolean(Recognition) && typeof window !== "undefined" && "speechSynthesis" in window;
+
+  const resetTranscript = useCallback(() => {
+    setLastTranscript("");
+  }, []);
 
   const clearRestartTimeout = useCallback(() => {
     if (restartTimeoutRef.current) {
@@ -27,21 +51,17 @@ const useVoiceChat = () => {
     }
   }, []);
 
-  const resetTranscript = useCallback(() => {
-    setLastTranscript("");
-  }, []);
-
   const stopListening = useCallback(() => {
-    isExpectedStopRef.current = true;
-    shouldBeListeningRef.current = false;
+    expectedStopRef.current = true;
+    shouldResumeRef.current = false;
     clearRestartTimeout();
-    setIsListening(false);
+    setListening(false);
 
     if (recognitionRef.current) {
       try {
         recognitionRef.current.stop();
-      } catch (error) {
-        // Some browsers throw if stop is called while inactive; ignore.
+      } catch {
+        /* ignore */
       }
     }
   }, [clearRestartTimeout]);
@@ -78,34 +98,35 @@ const useVoiceChat = () => {
 
       instance.onresult = handleResult;
       instance.onstart = () => {
-        setIsListening(true);
-        isExpectedStopRef.current = false;
+        setListening(true);
+        expectedStopRef.current = false;
+        setVoiceError(null);
       };
 
       instance.onend = () => {
-        setIsListening(false);
+        setListening(false);
 
-        if (isExpectedStopRef.current || !shouldBeListeningRef.current) {
-          isExpectedStopRef.current = false;
+        if (expectedStopRef.current || !shouldResumeRef.current) {
+          expectedStopRef.current = false;
           return;
         }
 
-        // iOS Safari often stops unexpectedly; restart to keep continuous mode alive.
         clearRestartTimeout();
-        restartTimeoutRef.current = setTimeout(() => {
+        restartTimeoutRef.current = window.setTimeout(() => {
           try {
             instance.start();
-          } catch (error) {
-            // Restart may fail if the microphone is busy; ignore and wait for next opportunity.
+          } catch {
+            /* ignore */
           }
-        }, 400);
+        }, 450);
       };
 
       instance.onerror = (event) => {
-        if (event.error === "not-allowed" || event.error === "service-not-allowed") {
-          shouldBeListeningRef.current = false;
-          isExpectedStopRef.current = true;
-        }
+        const message = ERROR_MESSAGES[event?.error] || "Voice input unavailable.";
+        setVoiceError(message);
+        shouldResumeRef.current = false;
+        expectedStopRef.current = true;
+        setListening(false);
       };
 
       recognitionRef.current = instance;
@@ -125,66 +146,91 @@ const useVoiceChat = () => {
       return;
     }
 
-    shouldBeListeningRef.current = true;
-    isExpectedStopRef.current = false;
+    shouldResumeRef.current = true;
+    expectedStopRef.current = false;
+    setVoiceError(null);
 
     try {
       recognition.start();
-    } catch (error) {
-      // Restart if already active.
+    } catch {
       try {
         recognition.stop();
         recognition.start();
-      } catch (retryError) {
-        // Ignore if retry fails; browser may still be starting.
+      } catch {
+        /* ignore */
       }
     }
   }, [Recognition, ensureRecognition]);
 
-  const speak = useCallback((text, options = {}) => {
-    if (!canSpeak || !text) {
-      return undefined;
-    }
+  const speak = useCallback(
+    (text, options = {}) => {
+      if (!canUseVoice || !text) {
+        return null;
+      }
 
-    window.speechSynthesis.cancel();
-    const utterance = new SpeechSynthesisUtterance(text);
+      window.speechSynthesis.cancel();
 
-    if (options.pitch) {
-      utterance.pitch = options.pitch;
-    }
+      const utterance = new SpeechSynthesisUtterance(text);
 
-    if (options.rate) {
-      utterance.rate = options.rate;
-    }
+      if (options.pitch !== undefined) {
+        utterance.pitch = options.pitch;
+      }
 
-    if (options.volume !== undefined) {
-      utterance.volume = options.volume;
-    }
+      if (options.rate !== undefined) {
+        utterance.rate = options.rate;
+      }
 
-    if (options.voice) {
-      utterance.voice = options.voice;
-    }
+      if (options.volume !== undefined) {
+        utterance.volume = options.volume;
+      }
 
-    window.speechSynthesis.speak(utterance);
-    return utterance;
-  }, [canSpeak]);
+      if (options.voice) {
+        utterance.voice = options.voice;
+      }
+
+      if (typeof options.onStart === "function") {
+        utterance.onstart = options.onStart;
+      }
+
+      if (typeof options.onBoundary === "function") {
+        utterance.onboundary = options.onBoundary;
+      }
+
+      const handleFinish = (event) => {
+        if (typeof options.onEnd === "function") {
+          options.onEnd(event);
+        }
+      };
+
+      utterance.onend = handleFinish;
+      utterance.oncancel = handleFinish;
+      utterance.onerror = handleFinish;
+
+      window.speechSynthesis.speak(utterance);
+      return utterance;
+    },
+    [canUseVoice]
+  );
 
   useEffect(() => () => {
     stopListening();
-    if (canSpeak) {
+    clearRestartTimeout();
+
+    if (typeof window !== "undefined" && "speechSynthesis" in window) {
       window.speechSynthesis.cancel();
     }
-  }, [stopListening, canSpeak]);
+  }, [stopListening, clearRestartTimeout]);
 
   return {
-    canListen,
-    canSpeak,
-    isListening,
-    lastTranscript,
-    resetTranscript,
-    speak,
+    canUseVoice,
+    listening,
     startListening,
     stopListening,
+    speak,
+    lastTranscript,
+    resetTranscript,
+    supportsFullDuplex,
+    voiceError,
   };
 };
 


### PR DESCRIPTION
## Summary
- refactor the voice chat hook to support continuous listening, duplex detection, and speech synthesis control
- redesign the chat box UI to surface listening/speaking indicators and accessibility improvements
- implement client-side barge-in by cancelling speech, aborting in-flight requests, and reusing the existing send logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d61fd2c5988330bbecd3c01a7aabbb