### PR TITLE
Add voice provider and fullscreen voice experience

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useAppSelector } from "./store/store.js";
 import { selectAuthToken } from "./store/ui/uiSlice.js";
 import { useCurrentUserQuery } from "./features/auth/hooks/useAuth.js";
@@ -23,7 +23,195 @@ import MyAppointments from "./pages/MyAppointments.jsx";
 import JournalsList from "./pages/JournalsList.jsx";
 import JournalForm from "./pages/JournalForm.jsx";
 import JournalDetail from "./pages/JournalDetail.jsx";
-import VoiceChat from "./pages/voice/VoiceChat.jsx";
+import VoiceScreen from "./pages/VoiceScreen.jsx";
+
+const AppShell = ({ isAuthenticated }) => {
+  const location = useLocation();
+  const hideChrome = location.pathname === "/voice";
+
+  return (
+    <div className="app dark">
+      {isAuthenticated && !hideChrome && <Header />}
+      <Routes>
+        <Route
+          path="/"
+          element={
+            <Navigate
+              to={isAuthenticated ? "/dashboard" : "/login"}
+              replace
+            />
+          }
+        />
+        <Route
+          path="/login"
+          element={
+            isAuthenticated ? <Navigate to="/dashboard" replace /> : <Login />
+          }
+        />
+        <Route
+          path="/register"
+          element={
+            isAuthenticated ? (
+              <Navigate to="/dashboard" replace />
+            ) : (
+              <Register />
+            )
+          }
+        />
+        <Route
+          path="/dashboard"
+          element={
+            isAuthenticated ? <Dashboard /> : <Navigate to="/login" replace />
+          }
+        />
+        <Route
+          path="/admin"
+          element={
+            isAuthenticated ? <AdminDashboard /> : <Navigate to="/login" replace />
+          }
+        />
+        <Route
+          path="/chat"
+          element={
+            isAuthenticated ? <Chat /> : <Navigate to="/login" replace />
+          }
+        />
+        <Route
+          path="/voice"
+          element={
+            isAuthenticated ? <VoiceScreen /> : <Navigate to="/login" replace />
+          }
+        />
+        <Route
+          path="/faceoff"
+          element={
+            isAuthenticated ? (
+              <FaceOffPage />
+            ) : (
+              <Navigate to="/login" replace />
+            )
+          }
+        />
+        <Route
+          path="/store"
+          element={
+            isAuthenticated ? <Store /> : <Navigate to="/login" replace />
+          }
+        />
+        <Route
+          path="/store/:id"
+          element={
+            isAuthenticated ? (
+              <ItemDetails />
+            ) : (
+              <Navigate to="/login" replace />
+            )
+          }
+        />
+        <Route
+          path="/cart"
+          element={
+            isAuthenticated ? <Cart /> : <Navigate to="/login" replace />
+          }
+        />
+        <Route
+          path="/checkout"
+          element={
+            isAuthenticated ? <Checkout /> : <Navigate to="/login" replace />
+          }
+        />
+        <Route
+          path="/appointments"
+          element={
+            isAuthenticated ? (
+              <AppointmentBrowse />
+            ) : (
+              <Navigate to="/login" replace />
+            )
+          }
+        />
+        <Route
+          path="/appointments/mine"
+          element={
+            isAuthenticated ? (
+              <MyAppointments />
+            ) : (
+              <Navigate to="/login" replace />
+            )
+          }
+        />
+        <Route
+          path="/journals"
+          element={
+            isAuthenticated ? (
+              <JournalsList />
+            ) : (
+              <Navigate to="/login" replace />
+            )
+          }
+        />
+        <Route
+          path="/journals/new"
+          element={
+            isAuthenticated ? (
+              <JournalForm mode="create" />
+            ) : (
+              <Navigate to="/login" replace />
+            )
+          }
+        />
+        <Route
+          path="/journals/:id"
+          element={
+            isAuthenticated ? (
+              <JournalDetail />
+            ) : (
+              <Navigate to="/login" replace />
+            )
+          }
+        />
+        <Route
+          path="/journals/:id/edit"
+          element={
+            isAuthenticated ? (
+              <JournalForm mode="edit" />
+            ) : (
+              <Navigate to="/login" replace />
+            )
+          }
+        />
+        <Route
+          path="/appointments/:id"
+          element={
+            isAuthenticated ? (
+              <AppointmentMidwife />
+            ) : (
+              <Navigate to="/login" replace />
+            )
+          }
+        />
+        <Route
+          path="/profile"
+          element={
+            isAuthenticated ? <Profile /> : <Navigate to="/login" replace />
+          }
+        />
+        <Route path="/welcome" element={<Navigate to="/profile" replace />} />
+        <Route
+          path="/onboarding"
+          element={
+            isAuthenticated ? (
+              <Onboarding />
+            ) : (
+              <Navigate to="/login" replace />
+            )
+          }
+        />
+      </Routes>
+      {isAuthenticated && !hideChrome && <Footer />}
+    </div>
+  );
+};
 
 const App = () => {
   const token = useAppSelector(selectAuthToken);
@@ -55,186 +243,7 @@ const App = () => {
 
   return (
     <BrowserRouter>
-      <div className="app dark">
-        {isAuthenticated && <Header />}
-        <Routes>
-          <Route
-            path="/"
-            element={
-              <Navigate
-                to={isAuthenticated ? "/dashboard" : "/login"}
-                replace
-              />
-            }
-          />
-          <Route
-            path="/login"
-            element={
-              isAuthenticated ? <Navigate to="/dashboard" replace /> : <Login />
-            }
-          />
-          <Route
-            path="/register"
-            element={
-              isAuthenticated ? (
-                <Navigate to="/dashboard" replace />
-              ) : (
-                <Register />
-              )
-            }
-          />
-          <Route
-            path="/dashboard"
-            element={
-              isAuthenticated ? <Dashboard /> : <Navigate to="/login" replace />
-            }
-          />
-          <Route
-            path="/admin"
-            element={
-              isAuthenticated ? <AdminDashboard /> : <Navigate to="/login" replace />
-            }
-          />
-          <Route
-            path="/chat"
-            element={
-              isAuthenticated ? <Chat /> : <Navigate to="/login" replace />
-            }
-          />
-          <Route
-            path="/voice"
-            element={
-              isAuthenticated ? <VoiceChat /> : <Navigate to="/login" replace />
-            }
-          />
-          <Route
-            path="/faceoff"
-            element={
-              isAuthenticated ? (
-                <FaceOffPage />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route
-            path="/store"
-            element={
-              isAuthenticated ? <Store /> : <Navigate to="/login" replace />
-            }
-          />
-          <Route
-            path="/store/:id"
-            element={
-              isAuthenticated ? (
-                <ItemDetails />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route
-            path="/cart"
-            element={
-              isAuthenticated ? <Cart /> : <Navigate to="/login" replace />
-            }
-          />
-          <Route
-            path="/checkout"
-            element={
-              isAuthenticated ? <Checkout /> : <Navigate to="/login" replace />
-            }
-          />
-          <Route
-            path="/appointments"
-            element={
-              isAuthenticated ? (
-                <AppointmentBrowse />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route
-            path="/appointments/mine"
-            element={
-              isAuthenticated ? (
-                <MyAppointments />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route
-            path="/journals"
-            element={
-              isAuthenticated ? (
-                <JournalsList />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route
-            path="/journals/new"
-            element={
-              isAuthenticated ? (
-                <JournalForm mode="create" />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route
-            path="/journals/:id"
-            element={
-              isAuthenticated ? (
-                <JournalDetail />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route
-            path="/journals/:id/edit"
-            element={
-              isAuthenticated ? (
-                <JournalForm mode="edit" />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route
-            path="/appointments/:id"
-            element={
-              isAuthenticated ? (
-                <AppointmentMidwife />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route
-            path="/profile"
-            element={
-              isAuthenticated ? <Profile /> : <Navigate to="/login" replace />
-            }
-          />
-          <Route path="/welcome" element={<Navigate to="/profile" replace />} />
-          <Route
-            path="/onboarding"
-            element={
-              isAuthenticated ? (
-                <Onboarding />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-        </Routes>
-        {isAuthenticated && <Footer />}
-      </div>
+      <AppShell isAuthenticated={isAuthenticated} />
     </BrowserRouter>
   );
 };

--- a/client/src/components/ChatBox/ChatBox.jsx
+++ b/client/src/components/ChatBox/ChatBox.jsx
@@ -1,17 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { FiMenu, FiMic, FiMicOff, FiPlay, FiPlus } from "react-icons/fi";
-import { http } from "../../api/http.js";
+import { FiMenu, FiMic, FiMicOff, FiPlay, FiPlus, FiMaximize2 } from "react-icons/fi";
+import { useNavigate } from "react-router-dom";
 import { useChatMessages } from "../../features/messages/hooks/useChatMessages.js";
-import useVoiceChat from "../../hooks/useVoiceChat.js";
+import { useVoiceContext, VoiceUIStates } from "../../state/voice/VoiceProvider.jsx";
 import styles from "../Chat/chat.module.scss";
-
-const UI_STATES = {
-  idle: "idle",
-  listening: "listening",
-  sending: "sending",
-  speaking: "speaking",
-  interrupting: "interrupting",
-};
 
 const formatTime = (value) => {
   try {
@@ -23,8 +15,6 @@ const formatTime = (value) => {
     return "";
   }
 };
-
-const genId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
 const WaveIcon = (props) => (
   <svg
@@ -46,24 +36,16 @@ const WaveIcon = (props) => (
   </svg>
 );
 
-const ChatBox = ({ daySummary }) => {
-  const { messages, appendMessages } = useChatMessages();
+const ChatBox = () => {
+  const { messages } = useChatMessages();
   const [input, setInput] = useState("");
-  const [isSending, setIsSending] = useState(false);
-  const [uiState, setUiState] = useState(UI_STATES.idle);
-  const [speaking, setSpeaking] = useState(false);
   const [speakingMessageId, setSpeakingMessageId] = useState(null);
   const [voiceNotice, setVoiceNotice] = useState(null);
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const scrollAnchorRef = useRef(null);
   const inputRef = useRef(null);
-  const lastSpokenRef = useRef(null);
-  const voiceQueueRef = useRef([]);
-  const abortControllerRef = useRef(null);
-  const requestIdRef = useRef(0);
-  const currentRequestIdRef = useRef(0);
   const liveRegionRef = useRef(null);
-  const activeUtteranceRef = useRef(null);
+  const navigate = useNavigate();
 
   const {
     canUseVoice,
@@ -71,11 +53,18 @@ const ChatBox = ({ daySummary }) => {
     startListening,
     stopListening,
     speak,
-    lastTranscript,
-    resetTranscript,
     supportsFullDuplex,
     voiceError,
-  } = useVoiceChat();
+    uiState,
+    setUiState,
+    speaking,
+    setSpeaking,
+    isSending,
+    sendViaExisting,
+    interrupt,
+    activeUtteranceRef,
+    lastSpokenRef,
+  } = useVoiceContext();
 
   const statusIsSpeaking = speaking || isSending;
   const statusDotClass = `${styles.statusDot} ${
@@ -141,158 +130,34 @@ const ChatBox = ({ daySummary }) => {
 
   const handleInterrupt = useCallback(
     ({ resumeListening = false, announceInterrupt = true } = {}) => {
-      let didInterrupt = false;
+      const didInterrupt = interrupt({ resumeListening });
 
-      setUiState(UI_STATES.interrupting);
-
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-        abortControllerRef.current = null;
-        didInterrupt = true;
-      }
-
-      if (typeof window !== "undefined" && window.speechSynthesis) {
-        window.speechSynthesis.cancel();
-        didInterrupt = true;
-      }
-
-      if (activeUtteranceRef.current) {
-        activeUtteranceRef.current = null;
+      if (didInterrupt) {
+        setSpeakingMessageId(null);
       }
 
       if (didInterrupt && announceInterrupt) {
         announce("Interrupted");
         vibrate();
       }
-
-      setSpeaking(false);
-      setSpeakingMessageId(null);
-      setIsSending(false);
-
-      if (resumeListening) {
-        setUiState(UI_STATES.listening);
-        startListening();
-      } else if (!listening) {
-        setUiState(UI_STATES.idle);
-      }
     },
-    [announce, vibrate, listening, startListening]
-  );
-
-  const sendMessage = useCallback(
-    async (text, { fromVoice = false } = {}) => {
-      const trimmed = text.trim();
-
-      if (!trimmed) {
-        return;
-      }
-
-      if (isSending) {
-        if (fromVoice) {
-          voiceQueueRef.current.push(trimmed);
-        }
-        return;
-      }
-
-      const userMessage = {
-        id: genId(),
-        role: "user",
-        content: trimmed,
-        timestamp: new Date().toISOString(),
-      };
-
-      if (!fromVoice) {
-        setInput("");
-      }
-
-      await appendMessages(userMessage);
-      setIsSending(true);
-      setVoiceNotice(null);
-      setUiState(UI_STATES.sending);
-
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
-
-      const abortController = new AbortController();
-      abortControllerRef.current = abortController;
-
-      const nextRequestId = requestIdRef.current + 1;
-      requestIdRef.current = nextRequestId;
-      currentRequestIdRef.current = nextRequestId;
-
-      try {
-        const payload = {
-          text: trimmed,
-          ...(daySummary
-            ? {
-                dayData: {
-                  dayIndex: daySummary.day,
-                  babyUpdate: daySummary.babyUpdate,
-                  momUpdate: daySummary.momUpdate,
-                  tips: daySummary.tips,
-                },
-              }
-            : {}),
-        };
-
-        const data = await http.post("/chat/ask", { json: payload, signal: abortController.signal });
-
-        if (nextRequestId !== currentRequestIdRef.current) {
-          return;
-        }
-
-        const assistantContent =
-          data?.content ||
-          data?.message ||
-          "I'm not sure how to respond right now, but I'm here for you.";
-
-        const assistantMessage = {
-          id: genId(),
-          role: "assistant",
-          content: assistantContent,
-          timestamp: new Date().toISOString(),
-          meta: data?.triage ? { triage: true } : undefined,
-        };
-
-        await appendMessages(assistantMessage);
-      } catch (error) {
-        if (error.name === "AbortError") {
-          return;
-        }
-
-        await appendMessages({
-          id: genId(),
-          role: "assistant",
-          content: error?.message || "Failed to send message.",
-          timestamp: new Date().toISOString(),
-        });
-      } finally {
-        if (nextRequestId === currentRequestIdRef.current) {
-          setIsSending(false);
-          abortControllerRef.current = null;
-          if (!fromVoice) {
-            inputRef.current?.focus();
-          }
-
-          if (listening) {
-            setUiState(UI_STATES.listening);
-          } else if (!speaking) {
-            setUiState(UI_STATES.idle);
-          }
-        }
-      }
-    },
-    [appendMessages, daySummary, isSending, listening, speaking]
+    [announce, interrupt, setSpeakingMessageId, vibrate]
   );
 
   const handleSubmit = useCallback(
     (event) => {
       event.preventDefault();
+      const trimmed = input.trim();
+
+      if (!trimmed) {
+        return;
+      }
+
+      setInput("");
       inputRef.current?.focus();
-      void sendMessage(input);
+      void sendViaExisting(trimmed);
     },
-    [input, sendMessage]
+    [input, sendViaExisting]
   );
 
   const handleReplay = useCallback(
@@ -321,7 +186,7 @@ const ChatBox = ({ daySummary }) => {
         },
       });
     },
-    [speak, startListening, stopListening, supportsFullDuplex]
+    [setSpeaking, setSpeakingMessageId, speak, startListening, stopListening, supportsFullDuplex]
   );
 
   const handleMicPress = useCallback(() => {
@@ -336,12 +201,12 @@ const ChatBox = ({ daySummary }) => {
 
     if (listening) {
       stopListening();
-      setUiState(UI_STATES.idle);
+      setUiState(VoiceUIStates.idle);
     } else {
-      setUiState(UI_STATES.listening);
+      setUiState(VoiceUIStates.listening);
       startListening();
     }
-  }, [canUseVoice, handleInterrupt, listening, startListening, statusIsSpeaking, stopListening]);
+  }, [canUseVoice, handleInterrupt, listening, setUiState, startListening, statusIsSpeaking, stopListening]);
 
   useEffect(() => {
     if (typeof window === "undefined" || !window.matchMedia) {
@@ -371,38 +236,6 @@ const ChatBox = ({ daySummary }) => {
   useEffect(() => {
     scrollAnchorRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages.length, isSending]);
-
-  useEffect(() => {
-    if (!lastTranscript) {
-      return;
-    }
-
-    const trimmed = lastTranscript.trim();
-
-    if (!trimmed) {
-      resetTranscript();
-      return;
-    }
-
-    if (statusIsSpeaking) {
-      handleInterrupt({ resumeListening: false });
-    }
-
-    void sendMessage(trimmed, { fromVoice: true });
-    resetTranscript();
-  }, [handleInterrupt, lastTranscript, resetTranscript, sendMessage, statusIsSpeaking]);
-
-  useEffect(() => {
-    if (isSending) {
-      return;
-    }
-
-    const nextQueued = voiceQueueRef.current.shift();
-
-    if (nextQueued) {
-      void sendMessage(nextQueued, { fromVoice: true });
-    }
-  }, [isSending, sendMessage]);
 
   useEffect(() => {
     if (!messages.length || !canUseVoice) {
@@ -444,7 +277,7 @@ const ChatBox = ({ daySummary }) => {
         }
       },
     });
-  }, [canUseVoice, messages, speak, startListening, stopListening, supportsFullDuplex]);
+  }, [canUseVoice, messages, setSpeaking, setSpeakingMessageId, speak, startListening, stopListening, supportsFullDuplex]);
 
   useEffect(() => {
     if (!messages.length) {
@@ -458,33 +291,33 @@ const ChatBox = ({ daySummary }) => {
     }
 
     setVoiceNotice(voiceError);
-    setUiState((previous) => (previous === UI_STATES.listening ? UI_STATES.idle : previous));
-  }, [voiceError]);
+    setUiState((previous) => (previous === VoiceUIStates.listening ? VoiceUIStates.idle : previous));
+  }, [setUiState, voiceError]);
 
   useEffect(() => {
     if (listening) {
       setVoiceNotice(null);
       setUiState((previous) =>
-        previous === UI_STATES.sending || previous === UI_STATES.speaking
+        previous === VoiceUIStates.sending || previous === VoiceUIStates.speaking
           ? previous
-          : UI_STATES.listening
+          : VoiceUIStates.listening
       );
       announce("Listening started");
       vibrate();
-    } else if (uiState === UI_STATES.listening) {
-      setUiState(speaking ? UI_STATES.speaking : UI_STATES.idle);
+    } else if (uiState === VoiceUIStates.listening) {
+      setUiState(speaking ? VoiceUIStates.speaking : VoiceUIStates.idle);
       announce("Listening stopped");
     }
-  }, [announce, listening, speaking, uiState, vibrate]);
+  }, [announce, listening, setUiState, speaking, uiState, vibrate]);
 
   useEffect(() => {
     if (speaking) {
-      setUiState(UI_STATES.speaking);
+      setUiState(VoiceUIStates.speaking);
       announce("Speaking…");
     } else if (!listening && !isSending) {
-      setUiState(UI_STATES.idle);
+      setUiState(VoiceUIStates.idle);
     }
-  }, [announce, isSending, listening, speaking]);
+  }, [announce, isSending, listening, setUiState, speaking]);
 
   const renderMessage = useCallback(
     (entry, index) => {
@@ -602,6 +435,15 @@ const ChatBox = ({ daySummary }) => {
               ) : (
                 <FiMic aria-hidden="true" size={22} />
               )}
+            </button>
+
+            <button
+              type="button"
+              className={styles.roundButton}
+              onClick={() => navigate("/voice")}
+              aria-label="Open voice screen"
+            >
+              <FiMaximize2 aria-hidden="true" size={20} />
             </button>
 
             <button

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -16,6 +16,7 @@ import {
 import "./styles/global.scss";
 import CartProvider from "./context/CartContext.jsx";
 import BookingProvider from "./context/BookingContext.jsx";
+import VoiceProvider from "./state/voice/VoiceProvider.jsx";
 
 const shouldRetryQuery = (failureCount, error) => {
   if (error?.status === 401) {
@@ -61,7 +62,9 @@ ReactDOM.createRoot(document.getElementById("root")).render(
       <QueryClientProvider client={queryClient}>
         <CartProvider>
           <BookingProvider>
-            <App />
+            <VoiceProvider>
+              <App />
+            </VoiceProvider>
           </BookingProvider>
         </CartProvider>
         <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />

--- a/client/src/pages/Chat.jsx
+++ b/client/src/pages/Chat.jsx
@@ -2,8 +2,6 @@ import React from "react";
 import ChatBox from "../components/ChatBox/ChatBox.jsx";
 import { useTodayPregnancyQuery } from "../features/pregnancy/hooks/usePregnancy.js";
 import "../components/ChatBox/chatBox.styles.scss";
-import VoiceChat from "./voice/VoiceChat.jsx";
-
 const Chat = () => {
   const { data: todaySummary } = useTodayPregnancyQuery({
     enabled: true,

--- a/client/src/pages/VoiceScreen.jsx
+++ b/client/src/pages/VoiceScreen.jsx
@@ -1,0 +1,356 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  FiArrowLeft,
+  FiMic,
+  FiMicOff,
+  FiMoreHorizontal,
+  FiSettings,
+  FiShare2,
+  FiType,
+  FiX,
+} from "react-icons/fi";
+import { useNavigate } from "react-router-dom";
+import { useChatMessages } from "../features/messages/hooks/useChatMessages.js";
+import { useVoiceContext, VoiceUIStates } from "../state/voice/VoiceProvider.jsx";
+import styles from "./voiceScreen.module.scss";
+
+const VoiceScreen = () => {
+  const navigate = useNavigate();
+  const { messages } = useChatMessages();
+  const {
+    canUseVoice,
+    listening,
+    startListening,
+    stopListening,
+    speak,
+    supportsFullDuplex,
+    voiceError,
+    uiState,
+    setUiState,
+    speaking,
+    setSpeaking,
+    isSending,
+    interrupt,
+    latestTranscript,
+    activeUtteranceRef,
+    lastSpokenRef,
+  } = useVoiceContext();
+
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const statusAnnouncerRef = useRef(null);
+  const autoStartedRef = useRef(false);
+
+  const statusIsSpeaking = speaking || isSending;
+  const statusLabel = statusIsSpeaking ? "Assistant speaking" : listening ? "Listening" : "Idle";
+
+  const statusDotClass = useMemo(() => {
+    if (statusIsSpeaking) {
+      return `${styles.statusDot} ${styles.statusDotSpeaking}`;
+    }
+    if (listening) {
+      return `${styles.statusDot} ${styles.statusDotListening}`;
+    }
+    return styles.statusDot;
+  }, [listening, statusIsSpeaking]);
+
+  const orbClassName = useMemo(() => {
+    const classNames = [styles.orb];
+
+    if (listening) {
+      classNames.push(styles.orbListening);
+    }
+
+    if (statusIsSpeaking) {
+      classNames.push(styles.orbSpeaking);
+    }
+
+    if (prefersReducedMotion) {
+      classNames.push(styles.orbReduceMotion);
+    }
+
+    return classNames.join(" ");
+  }, [listening, prefersReducedMotion, statusIsSpeaking]);
+
+  const micLabel = statusIsSpeaking
+    ? "Tap to interrupt"
+    : listening
+    ? "Stop voice input"
+    : "Start voice input";
+
+  const queueAnimationFrame = useCallback((callback) => {
+    if (typeof window === "undefined") {
+      callback();
+      return;
+    }
+
+    const raf = window.requestAnimationFrame || window.setTimeout;
+    raf(() => callback());
+  }, []);
+
+  const announce = useCallback(
+    (message) => {
+      if (!statusAnnouncerRef.current) {
+        return;
+      }
+
+      statusAnnouncerRef.current.textContent = "";
+      queueAnimationFrame(() => {
+        if (statusAnnouncerRef.current) {
+          statusAnnouncerRef.current.textContent = message;
+        }
+      });
+    },
+    [queueAnimationFrame]
+  );
+
+  const vibrate = useCallback(() => {
+    if (prefersReducedMotion) {
+      return;
+    }
+
+    if (typeof navigator !== "undefined" && navigator.vibrate) {
+      navigator.vibrate(20);
+    }
+  }, [prefersReducedMotion]);
+
+  const toggleListening = useCallback(() => {
+    if (!canUseVoice) {
+      return;
+    }
+
+    if (statusIsSpeaking) {
+      const didInterrupt = interrupt({ resumeListening: true });
+      if (didInterrupt) {
+        announce("Interrupted");
+        vibrate();
+      }
+      return;
+    }
+
+    if (listening) {
+      stopListening();
+      setUiState(VoiceUIStates.idle);
+      announce("Listening stopped");
+    } else {
+      setUiState(VoiceUIStates.listening);
+      startListening();
+      announce("Listening started");
+      vibrate();
+    }
+  }, [announce, canUseVoice, interrupt, listening, setUiState, startListening, statusIsSpeaking, stopListening, vibrate]);
+
+  const handleBack = useCallback(() => {
+    navigate("/chat");
+  }, [navigate]);
+
+  const handleMore = useCallback(() => {
+    console.log("Voice options coming soon");
+  }, []);
+
+  const handleEnd = useCallback(() => {
+    interrupt({ resumeListening: false });
+    stopListening();
+    setUiState(VoiceUIStates.idle);
+    navigate("/chat");
+  }, [interrupt, navigate, setUiState, stopListening]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handleChange = (event) => setPrefersReducedMotion(event.matches);
+
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener("change", handleChange);
+    } else {
+      mediaQuery.addListener(handleChange);
+    }
+
+    return () => {
+      if (mediaQuery.removeEventListener) {
+        mediaQuery.removeEventListener("change", handleChange);
+      } else {
+        mediaQuery.removeListener(handleChange);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!canUseVoice || autoStartedRef.current) {
+      return;
+    }
+
+    if (!listening && uiState === VoiceUIStates.idle) {
+      autoStartedRef.current = true;
+      setUiState(VoiceUIStates.listening);
+      startListening();
+      announce("Listening started");
+    }
+  }, [announce, canUseVoice, listening, setUiState, startListening, uiState]);
+
+  useEffect(() => {
+    if (!messages.length || !canUseVoice) {
+      return;
+    }
+
+    const latestAssistant = [...messages]
+      .reverse()
+      .find((message) => message?.role === "assistant" && message?.content);
+
+    if (!latestAssistant) {
+      return;
+    }
+
+    const messageKey = latestAssistant.id || latestAssistant.timestamp || latestAssistant.content;
+
+    if (lastSpokenRef.current === messageKey) {
+      return;
+    }
+
+    lastSpokenRef.current = messageKey;
+
+    activeUtteranceRef.current = speak(latestAssistant.content, {
+      rate: 0.96,
+      pitch: 1,
+      volume: 1,
+      onStart: () => {
+        setSpeaking(true);
+        if (!supportsFullDuplex) {
+          stopListening();
+        }
+      },
+      onEnd: () => {
+        setSpeaking(false);
+        if (!supportsFullDuplex) {
+          startListening();
+        }
+      },
+    });
+  }, [
+    activeUtteranceRef,
+    canUseVoice,
+    lastSpokenRef,
+    messages,
+    setSpeaking,
+    speak,
+    startListening,
+    stopListening,
+    supportsFullDuplex,
+  ]);
+
+  useEffect(() => {
+    if (!messages.length) {
+      lastSpokenRef.current = null;
+    }
+  }, [lastSpokenRef, messages.length]);
+
+  useEffect(() => {
+    if (voiceError) {
+      announce(voiceError);
+    }
+  }, [announce, voiceError]);
+
+  useEffect(() => {
+    if (uiState === VoiceUIStates.listening) {
+      announce("Listening…");
+    } else if (uiState === VoiceUIStates.speaking) {
+      announce("Speaking…");
+    } else if (uiState === VoiceUIStates.sending) {
+      announce("Thinking…");
+    }
+  }, [announce, uiState]);
+
+  const statusChip = useMemo(() => {
+    if (statusIsSpeaking) {
+      return "Speaking…";
+    }
+
+    if (uiState === VoiceUIStates.sending) {
+      return "Thinking…";
+    }
+
+    if (listening) {
+      return "Listening…";
+    }
+
+    return "Idle";
+  }, [listening, statusIsSpeaking, uiState]);
+
+  const captionText = latestTranscript || (listening ? "Listening…" : "Tap the mic to start");
+
+  return (
+    <div className={styles.voiceScreen} role="application" aria-label="Voice conversation mode">
+      <header className={styles.topBar}>
+        <button type="button" className={styles.iconButton} onClick={handleBack} aria-label="Back to chat">
+          <FiArrowLeft aria-hidden="true" size={22} />
+        </button>
+        <div className={styles.statusGroup}>
+          <span className={statusDotClass} aria-hidden="true" />
+          <span className={styles.statusLabel}>{statusLabel}</span>
+          <span className={styles.statusChip}>{statusChip}</span>
+        </div>
+        <div className={styles.topActions}>
+          <button type="button" className={styles.iconButton} aria-label="Captions" onClick={() => {}}>
+            <FiType aria-hidden="true" size={18} />
+          </button>
+          <button type="button" className={styles.iconButton} aria-label="Share" onClick={() => {}}>
+            <FiShare2 aria-hidden="true" size={18} />
+          </button>
+          <button type="button" className={styles.iconButton} aria-label="Settings" onClick={() => {}}>
+            <FiSettings aria-hidden="true" size={18} />
+          </button>
+        </div>
+      </header>
+
+      <main className={styles.body}>
+        <div className={styles.captionArea} aria-live="polite" aria-atomic="true">
+          <span>{captionText}</span>
+        </div>
+        <div className={styles.orbWrapper}>
+          <div className={orbClassName} />
+        </div>
+        {voiceError && (
+          <div className={styles.voiceError} role="status" aria-live="polite">
+            {voiceError}
+          </div>
+        )}
+      </main>
+
+      <footer className={styles.controls}>
+        <div className={styles.bottomActions}>
+          <button type="button" className={styles.controlButton} onClick={handleBack} aria-label="Back to chat">
+            <FiArrowLeft aria-hidden="true" size={22} />
+          </button>
+          <button
+            type="button"
+            className={`${styles.controlButton} ${listening ? styles.controlButtonActive : ""}`.trim()}
+            onClick={toggleListening}
+            aria-label={micLabel}
+            aria-pressed={listening}
+            disabled={!canUseVoice}
+          >
+            {statusIsSpeaking || listening ? (
+              <FiMicOff aria-hidden="true" size={22} />
+            ) : (
+              <FiMic aria-hidden="true" size={22} />
+            )}
+          </button>
+          <button type="button" className={styles.controlButton} onClick={handleMore} aria-label="More options">
+            <FiMoreHorizontal aria-hidden="true" size={22} />
+          </button>
+          <button type="button" className={styles.controlButton} onClick={handleEnd} aria-label="End voice session">
+            <FiX aria-hidden="true" size={22} />
+          </button>
+        </div>
+      </footer>
+
+      <span className={styles.statusAnnouncer} ref={statusAnnouncerRef} aria-live="polite" aria-atomic="true" />
+    </div>
+  );
+};
+
+export default VoiceScreen;

--- a/client/src/pages/voiceScreen.module.scss
+++ b/client/src/pages/voiceScreen.module.scss
@@ -1,0 +1,252 @@
+.voiceScreen {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background: radial-gradient(circle at top, rgba(84, 87, 255, 0.25), transparent 60%),
+    radial-gradient(circle at bottom, rgba(255, 99, 132, 0.18), transparent 65%),
+    #050510;
+  color: #ffffff;
+  padding: 1.5rem 1.25rem 2rem;
+  z-index: 30;
+}
+
+.topBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.iconButton {
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  transition: background 0.2s ease, transform 0.2s ease;
+
+  &:active {
+    transform: scale(0.96);
+  }
+}
+
+.statusGroup {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.statusDot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.4);
+  box-shadow: 0 0 0 rgba(255, 255, 255, 0.15);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.statusDotListening {
+  background: #f4b63f;
+  box-shadow: 0 0 12px rgba(244, 182, 63, 0.55);
+}
+
+.statusDotSpeaking {
+  background: #1ed760;
+  box-shadow: 0 0 16px rgba(30, 215, 96, 0.6);
+}
+
+.statusLabel {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.75;
+}
+
+.statusChip {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.topActions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 2.5rem;
+  padding: 2rem 0 1.5rem;
+}
+
+.captionArea {
+  min-height: 3.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.9);
+  text-shadow: 0 1px 10px rgba(0, 0, 0, 0.35);
+}
+
+.orbWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.orb {
+  position: relative;
+  width: min(68vw, 320px);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85), rgba(81, 103, 255, 0.35));
+  box-shadow: 0 25px 55px rgba(0, 0, 0, 0.45);
+  transition: transform 0.8s ease, box-shadow 0.4s ease;
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: -18%;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(81, 103, 255, 0.2), transparent 70%);
+    opacity: 0;
+    transform: scale(0.9);
+  }
+}
+
+@keyframes orbPulse {
+  0%,
+  100% {
+    transform: scale(0.96);
+  }
+  50% {
+    transform: scale(1.03);
+  }
+}
+
+@keyframes orbSpeak {
+  0% {
+    transform: scale(1);
+    opacity: 0.45;
+  }
+  70% {
+    transform: scale(1.15);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1.15);
+    opacity: 0;
+  }
+}
+
+.orbListening {
+  animation: orbPulse 3.2s ease-in-out infinite;
+}
+
+.orbSpeaking {
+  animation: orbPulse 1.6s ease-in-out infinite;
+
+  &::after {
+    opacity: 0.75;
+    animation: orbSpeak 1.4s ease-out infinite;
+  }
+}
+
+.orbReduceMotion {
+  animation: none;
+
+  &::after {
+    animation: none;
+    opacity: 0.4;
+  }
+}
+
+.voiceError {
+  padding: 0.75rem 1rem;
+  background: rgba(255, 84, 84, 0.16);
+  border-radius: 12px;
+  color: #ff9d9d;
+  font-size: 0.85rem;
+}
+
+.controls {
+  display: flex;
+  justify-content: center;
+  padding-top: 1rem;
+}
+
+.bottomActions {
+  display: flex;
+  gap: 1rem;
+}
+
+.controlButton {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.15rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+
+  &:active {
+    transform: scale(0.95);
+  }
+}
+
+.controlButtonActive {
+  background: rgba(81, 103, 255, 0.3);
+  box-shadow: 0 0 16px rgba(81, 103, 255, 0.45);
+}
+
+.statusAnnouncer {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (min-width: 768px) {
+  .voiceScreen {
+    padding: 2.5rem 3rem 3rem;
+  }
+
+  .captionArea {
+    font-size: 1.4rem;
+  }
+
+  .orb {
+    width: min(38vw, 420px);
+  }
+
+  .controlButton {
+    width: 70px;
+    height: 70px;
+    font-size: 1.3rem;
+  }
+}

--- a/client/src/state/voice/VoiceProvider.jsx
+++ b/client/src/state/voice/VoiceProvider.jsx
@@ -1,0 +1,342 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { http } from "../../api/http.js";
+import { useChatMessages } from "../../features/messages/hooks/useChatMessages.js";
+import { useTodayPregnancyQuery } from "../../features/pregnancy/hooks/usePregnancy.js";
+import useVoiceChat from "../../hooks/useVoiceChat.js";
+
+export const VoiceUIStates = {
+  idle: "idle",
+  listening: "listening",
+  sending: "sending",
+  speaking: "speaking",
+  interrupting: "interrupting",
+};
+
+const VoiceContext = createContext(null);
+
+const genId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+const VoiceProvider = ({ children }) => {
+  const { appendMessages } = useChatMessages();
+  const { data: daySummary } = useTodayPregnancyQuery({ enabled: true });
+
+  const {
+    canUseVoice,
+    listening,
+    startListening,
+    stopListening,
+    speak,
+    lastTranscript: recognitionTranscript,
+    resetTranscript,
+    supportsFullDuplex,
+    voiceError,
+  } = useVoiceChat();
+
+  const [uiState, setUiState] = useState(VoiceUIStates.idle);
+  const [speaking, setSpeaking] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const [currentRequestId, setCurrentRequestId] = useState(0);
+  const [latestTranscript, setLatestTranscript] = useState("");
+
+  const listeningRef = useRef(listening);
+  const speakingRef = useRef(speaking);
+  const sendingRef = useRef(isSending);
+  const abortControllerRef = useRef(null);
+  const requestCounterRef = useRef(0);
+  const currentRequestIdRef = useRef(0);
+  const voiceQueueRef = useRef([]);
+  const activeUtteranceRef = useRef(null);
+  const lastSpokenRef = useRef(null);
+
+  useEffect(() => {
+    listeningRef.current = listening;
+  }, [listening]);
+
+  useEffect(() => {
+    speakingRef.current = speaking;
+  }, [speaking]);
+
+  useEffect(() => {
+    sendingRef.current = isSending;
+  }, [isSending]);
+
+  const clearAbortController = useCallback(() => {
+    abortControllerRef.current = null;
+  }, []);
+
+  const abortActiveRequest = useCallback(() => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
+    currentRequestIdRef.current = 0;
+    setCurrentRequestId(0);
+  }, []);
+
+  const interrupt = useCallback(
+    ({ resumeListening = false } = {}) => {
+      let interrupted = false;
+
+      setUiState(VoiceUIStates.interrupting);
+
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+        abortControllerRef.current = null;
+        interrupted = true;
+      }
+
+      if (typeof window !== "undefined" && window.speechSynthesis) {
+        window.speechSynthesis.cancel();
+        interrupted = true;
+      }
+
+      if (activeUtteranceRef.current) {
+        activeUtteranceRef.current = null;
+      }
+
+      setIsSending(false);
+      sendingRef.current = false;
+      setSpeaking(false);
+
+      if (resumeListening) {
+        setUiState(VoiceUIStates.listening);
+        startListening();
+      } else if (listeningRef.current) {
+        setUiState(VoiceUIStates.listening);
+      } else if (!speakingRef.current) {
+        setUiState(VoiceUIStates.idle);
+      }
+
+      return interrupted;
+    },
+    [startListening]
+  );
+
+  const sendViaExisting = useCallback(
+    async function sendViaExistingInner(rawText, options = {}) {
+      const { fromVoice = false } = options;
+      const trimmed = typeof rawText === "string" ? rawText.trim() : "";
+
+      if (!trimmed) {
+        return;
+      }
+
+      if (sendingRef.current) {
+        if (fromVoice) {
+          voiceQueueRef.current.push(trimmed);
+        }
+        return;
+      }
+
+      const userMessage = {
+        id: genId(),
+        role: "user",
+        content: trimmed,
+        timestamp: new Date().toISOString(),
+      };
+
+      await appendMessages(userMessage);
+
+      setIsSending(true);
+      sendingRef.current = true;
+      setUiState(VoiceUIStates.sending);
+
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+
+      const nextRequestId = requestCounterRef.current + 1;
+      requestCounterRef.current = nextRequestId;
+      currentRequestIdRef.current = nextRequestId;
+      setCurrentRequestId(nextRequestId);
+
+      try {
+        const payload = { text: trimmed };
+
+        if (daySummary) {
+          payload.dayData = {
+            dayIndex: daySummary.day,
+            babyUpdate: daySummary.babyUpdate,
+            momUpdate: daySummary.momUpdate,
+            tips: daySummary.tips,
+          };
+        }
+
+        const data = await http.post("/chat/ask", {
+          json: payload,
+          signal: abortController.signal,
+        });
+
+        if (currentRequestIdRef.current !== nextRequestId) {
+          return;
+        }
+
+        const assistantContent =
+          data?.content ||
+          data?.message ||
+          "I'm not sure how to respond right now, but I'm here for you.";
+
+        const assistantMessage = {
+          id: genId(),
+          role: "assistant",
+          content: assistantContent,
+          timestamp: new Date().toISOString(),
+          meta: data?.triage ? { triage: true } : undefined,
+        };
+
+        await appendMessages(assistantMessage);
+      } catch (error) {
+        if (error?.name === "AbortError") {
+          return;
+        }
+
+        await appendMessages({
+          id: genId(),
+          role: "assistant",
+          content: error?.message || "Failed to send message.",
+          timestamp: new Date().toISOString(),
+        });
+      } finally {
+        if (currentRequestIdRef.current === nextRequestId) {
+          clearAbortController();
+          currentRequestIdRef.current = 0;
+          setCurrentRequestId(0);
+          setIsSending(false);
+          sendingRef.current = false;
+
+          if (listeningRef.current) {
+            setUiState(VoiceUIStates.listening);
+          } else if (!speakingRef.current) {
+            setUiState(VoiceUIStates.idle);
+          }
+
+          const nextQueued = voiceQueueRef.current.shift();
+
+          if (nextQueued) {
+            const schedule = () =>
+              sendViaExistingInner(nextQueued, { fromVoice: true });
+
+            if (typeof window !== "undefined" && window.setTimeout) {
+              window.setTimeout(schedule, 0);
+            } else {
+              schedule();
+            }
+          }
+        }
+      }
+    },
+    [appendMessages, clearAbortController, daySummary]
+  );
+
+  useEffect(() => {
+    if (!recognitionTranscript) {
+      return;
+    }
+
+    const trimmed = recognitionTranscript.trim();
+
+    if (!trimmed) {
+      resetTranscript();
+      return;
+    }
+
+    setLatestTranscript(trimmed);
+
+    if (speakingRef.current || sendingRef.current) {
+      interrupt({ resumeListening: false });
+    }
+
+    void sendViaExisting(trimmed, { fromVoice: true });
+    resetTranscript();
+  }, [interrupt, recognitionTranscript, resetTranscript, sendViaExisting]);
+
+  useEffect(() => {
+    if (listening) {
+      setUiState((previous) => {
+        if (previous === VoiceUIStates.sending || previous === VoiceUIStates.speaking) {
+          return previous;
+        }
+        return VoiceUIStates.listening;
+      });
+    } else if (!sendingRef.current && !speakingRef.current) {
+      setUiState(VoiceUIStates.idle);
+    }
+  }, [listening]);
+
+  useEffect(() => {
+    if (speaking) {
+      setUiState(VoiceUIStates.speaking);
+    } else if (!listeningRef.current && !sendingRef.current) {
+      setUiState(VoiceUIStates.idle);
+    }
+  }, [speaking]);
+
+  const value = useMemo(
+    () => ({
+      canUseVoice,
+      listening,
+      startListening,
+      stopListening,
+      speak,
+      supportsFullDuplex,
+      voiceError,
+      uiState,
+      setUiState,
+      speaking,
+      setSpeaking,
+      isSending,
+      sendViaExisting,
+      interrupt,
+      abortActiveRequest,
+      currentRequestId,
+      latestTranscript,
+      resetTranscript,
+      activeUtteranceRef,
+      lastSpokenRef,
+    }),
+    [
+      abortActiveRequest,
+      canUseVoice,
+      currentRequestId,
+      interrupt,
+      isSending,
+      latestTranscript,
+      listening,
+      setUiState,
+      speak,
+      speaking,
+      startListening,
+      stopListening,
+      supportsFullDuplex,
+      uiState,
+      sendViaExisting,
+      setSpeaking,
+      voiceError,
+    ]
+  );
+
+  return <VoiceContext.Provider value={value}>{children}</VoiceContext.Provider>;
+};
+
+export const useVoiceContext = () => {
+  const context = useContext(VoiceContext);
+
+  if (!context) {
+    throw new Error("useVoiceContext must be used within a VoiceProvider");
+  }
+
+  return context;
+};
+
+export default VoiceProvider;


### PR DESCRIPTION
## Summary
- add a voice provider to centralize recognition, speech state, and message delivery
- update chat box to consume the shared voice context and link to the new voice mode
- introduce a fullscreen VoiceScreen experience with dedicated styling and routing

## Testing
- /root/.nvm/versions/node/v20.19.4/bin/npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68d625724bd88330a6314fa7a71a4e3d