### PR TITLE
Fix voice mode capture flow and mobile barge-in handling

### DIFF
--- a/client/src/hooks/useVoiceChat.js
+++ b/client/src/hooks/useVoiceChat.js
@@ -81,6 +81,7 @@ const useVoiceChat = () => {
     }
 
     if (transcript) {
+      console.log("[voice] final:", transcript);
       setLastTranscript(transcript);
     }
   }, []);
@@ -105,6 +106,7 @@ const useVoiceChat = () => {
 
       instance.onend = () => {
         setListening(false);
+        console.log("[voice] end, listening=", shouldResumeRef.current);
 
         if (expectedStopRef.current || !shouldResumeRef.current) {
           expectedStopRef.current = false;
@@ -118,7 +120,7 @@ const useVoiceChat = () => {
           } catch {
             /* ignore */
           }
-        }, 450);
+        }, 150);
       };
 
       instance.onerror = (event) => {

--- a/client/src/pages/VoiceScreen.jsx
+++ b/client/src/pages/VoiceScreen.jsx
@@ -32,13 +32,19 @@ const VoiceScreen = () => {
     isSending,
     interrupt,
     latestTranscript,
+    latestTranscriptId,
     activeUtteranceRef,
     lastSpokenRef,
+    sendViaExisting,
+    abortActiveRequest,
+    resetTranscript,
   } = useVoiceContext();
 
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const statusAnnouncerRef = useRef(null);
-  const autoStartedRef = useRef(false);
+  const hasUserGestureRef = useRef(false);
+  const lastTranscriptTokenRef = useRef(null);
+  const lastReplyLoggedRef = useRef(null);
 
   const statusIsSpeaking = speaking || isSending;
   const statusLabel = statusIsSpeaking ? "Assistant speaking" : listening ? "Listening" : "Idle";
@@ -118,6 +124,8 @@ const VoiceScreen = () => {
       return;
     }
 
+    hasUserGestureRef.current = true;
+
     if (statusIsSpeaking) {
       const didInterrupt = interrupt({ resumeListening: true });
       if (didInterrupt) {
@@ -140,8 +148,12 @@ const VoiceScreen = () => {
   }, [announce, canUseVoice, interrupt, listening, setUiState, startListening, statusIsSpeaking, stopListening, vibrate]);
 
   const handleBack = useCallback(() => {
+    abortActiveRequest();
+    if (typeof window !== "undefined" && window.speechSynthesis) {
+      window.speechSynthesis.cancel();
+    }
     navigate("/chat");
-  }, [navigate]);
+  }, [abortActiveRequest, navigate]);
 
   const handleMore = useCallback(() => {
     console.log("Voice options coming soon");
@@ -150,9 +162,13 @@ const VoiceScreen = () => {
   const handleEnd = useCallback(() => {
     interrupt({ resumeListening: false });
     stopListening();
+    abortActiveRequest();
+    if (typeof window !== "undefined" && window.speechSynthesis) {
+      window.speechSynthesis.cancel();
+    }
     setUiState(VoiceUIStates.idle);
     navigate("/chat");
-  }, [interrupt, navigate, setUiState, stopListening]);
+  }, [abortActiveRequest, interrupt, navigate, setUiState, stopListening]);
 
   useEffect(() => {
     if (typeof window === "undefined" || !window.matchMedia) {
@@ -180,17 +196,66 @@ const VoiceScreen = () => {
   }, []);
 
   useEffect(() => {
-    if (!canUseVoice || autoStartedRef.current) {
+    const token = latestTranscriptId;
+
+    if (!token || token === lastTranscriptTokenRef.current) {
       return;
     }
 
-    if (!listening && uiState === VoiceUIStates.idle) {
-      autoStartedRef.current = true;
-      setUiState(VoiceUIStates.listening);
-      startListening();
-      announce("Listening started");
+    lastTranscriptTokenRef.current = token;
+
+    const text = (latestTranscript || "").trim();
+
+    if (!text) {
+      resetTranscript();
+      return;
     }
-  }, [announce, canUseVoice, listening, setUiState, startListening, uiState]);
+
+    const process = async () => {
+      if (typeof window !== "undefined" && window.speechSynthesis) {
+        window.speechSynthesis.cancel();
+      }
+
+      if (statusIsSpeaking) {
+        abortActiveRequest();
+        interrupt({ resumeListening: false });
+      }
+
+      resetTranscript();
+
+      if (!listening) {
+        setUiState(VoiceUIStates.listening);
+      }
+
+      startListening();
+
+      console.log("[voice] sending:", text);
+
+      try {
+        const reply = await sendViaExisting(text, { fromVoice: true });
+
+        if (reply && lastReplyLoggedRef.current?.token !== token) {
+          lastReplyLoggedRef.current = { token, text: reply };
+          console.log("[voice] reply:", reply);
+        }
+      } catch {
+        lastReplyLoggedRef.current = null;
+      }
+    };
+
+    void process();
+  }, [
+    abortActiveRequest,
+    interrupt,
+    latestTranscript,
+    latestTranscriptId,
+    listening,
+    sendViaExisting,
+    setUiState,
+    startListening,
+    statusIsSpeaking,
+    resetTranscript,
+  ]);
 
   useEffect(() => {
     if (!messages.length || !canUseVoice) {
@@ -211,9 +276,25 @@ const VoiceScreen = () => {
       return;
     }
 
+    if (!hasUserGestureRef.current) {
+      return;
+    }
+
     lastSpokenRef.current = messageKey;
 
-    activeUtteranceRef.current = speak(latestAssistant.content, {
+    const replyText = latestAssistant.content;
+
+    if (!replyText) {
+      return;
+    }
+
+    if (!supportsFullDuplex) {
+      stopListening();
+    }
+
+    console.log("[voice] speak:", replyText);
+
+    activeUtteranceRef.current = speak(replyText, {
       rate: 0.96,
       pitch: 1,
       volume: 1,

--- a/client/src/state/voice/VoiceProvider.jsx
+++ b/client/src/state/voice/VoiceProvider.jsx
@@ -45,6 +45,7 @@ const VoiceProvider = ({ children }) => {
   const [isSending, setIsSending] = useState(false);
   const [currentRequestId, setCurrentRequestId] = useState(0);
   const [latestTranscript, setLatestTranscript] = useState("");
+  const [latestTranscriptId, setLatestTranscriptId] = useState(0);
 
   const listeningRef = useRef(listening);
   const speakingRef = useRef(speaking);
@@ -70,6 +71,11 @@ const VoiceProvider = ({ children }) => {
 
   const clearAbortController = useCallback(() => {
     abortControllerRef.current = null;
+  }, []);
+
+  const clearLatestTranscript = useCallback(() => {
+    setLatestTranscript("");
+    setLatestTranscriptId(0);
   }, []);
 
   const abortActiveRequest = useCallback(() => {
@@ -196,9 +202,10 @@ const VoiceProvider = ({ children }) => {
         };
 
         await appendMessages(assistantMessage);
+        return assistantContent;
       } catch (error) {
         if (error?.name === "AbortError") {
-          return;
+          return null;
         }
 
         await appendMessages({
@@ -207,6 +214,7 @@ const VoiceProvider = ({ children }) => {
           content: error?.message || "Failed to send message.",
           timestamp: new Date().toISOString(),
         });
+        return null;
       } finally {
         if (currentRequestIdRef.current === nextRequestId) {
           clearAbortController();
@@ -252,14 +260,9 @@ const VoiceProvider = ({ children }) => {
     }
 
     setLatestTranscript(trimmed);
-
-    if (speakingRef.current || sendingRef.current) {
-      interrupt({ resumeListening: false });
-    }
-
-    void sendViaExisting(trimmed, { fromVoice: true });
+    setLatestTranscriptId((previous) => previous + 1);
     resetTranscript();
-  }, [interrupt, recognitionTranscript, resetTranscript, sendViaExisting]);
+  }, [recognitionTranscript, resetTranscript]);
 
   useEffect(() => {
     if (listening) {
@@ -301,9 +304,11 @@ const VoiceProvider = ({ children }) => {
       abortActiveRequest,
       currentRequestId,
       latestTranscript,
+      latestTranscriptId,
       resetTranscript,
       activeUtteranceRef,
       lastSpokenRef,
+      clearLatestTranscript,
     }),
     [
       abortActiveRequest,
@@ -312,6 +317,7 @@ const VoiceProvider = ({ children }) => {
       interrupt,
       isSending,
       latestTranscript,
+      latestTranscriptId,
       listening,
       setUiState,
       speak,
@@ -322,6 +328,7 @@ const VoiceProvider = ({ children }) => {
       uiState,
       sendViaExisting,
       setSpeaking,
+      clearLatestTranscript,
       voiceError,
     ]
   );


### PR DESCRIPTION
## Summary
- wire the voice screen into the existing chat send helper and add diagnostics around send, reply, and speak events
- improve speech recognition handling with faster restarts, final-result logging, and transcript sequencing for barge-in behaviour
- ensure iOS half-duplex flow pauses listening during TTS, cancels playback on interrupts, and resumes recognition after replies

## Testing
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_68d62c9ab4dc8330a188b8eaf45ffe8f