### PR TITLE
Fix voice playback on devices without speech recognition

### DIFF
--- a/client/src/components/ChatBox/ChatBox.jsx
+++ b/client/src/components/ChatBox/ChatBox.jsx
@@ -49,6 +49,7 @@ const ChatBox = () => {
 
   const {
     canUseVoice,
+    canSpeak,
     listening,
     startListening,
     stopListening,
@@ -162,7 +163,7 @@ const ChatBox = () => {
 
   const handleReplay = useCallback(
     (message) => {
-      if (!message?.content) {
+      if (!canSpeak || !message?.content) {
         return;
       }
 
@@ -186,7 +187,15 @@ const ChatBox = () => {
         },
       });
     },
-    [setSpeaking, setSpeakingMessageId, speak, startListening, stopListening, supportsFullDuplex]
+    [
+      canSpeak,
+      setSpeaking,
+      setSpeakingMessageId,
+      speak,
+      startListening,
+      stopListening,
+      supportsFullDuplex,
+    ]
   );
 
   const handleMicPress = useCallback(() => {
@@ -238,7 +247,7 @@ const ChatBox = () => {
   }, [messages.length, isSending]);
 
   useEffect(() => {
-    if (!messages.length || !canUseVoice) {
+    if (!messages.length || !canSpeak) {
       return;
     }
 
@@ -277,7 +286,16 @@ const ChatBox = () => {
         }
       },
     });
-  }, [canUseVoice, messages, setSpeaking, setSpeakingMessageId, speak, startListening, stopListening, supportsFullDuplex]);
+  }, [
+    canSpeak,
+    messages,
+    setSpeaking,
+    setSpeakingMessageId,
+    speak,
+    startListening,
+    stopListening,
+    supportsFullDuplex,
+  ]);
 
   useEffect(() => {
     if (!messages.length) {
@@ -340,7 +358,7 @@ const ChatBox = () => {
                     className={styles.playButton}
                     onClick={() => handleReplay(entry)}
                     aria-label="Replay response"
-                    disabled={!canUseVoice}
+                    disabled={!canSpeak}
                   >
                     <FiPlay aria-hidden="true" size={18} />
                   </button>
@@ -362,7 +380,7 @@ const ChatBox = () => {
         </div>
       );
     },
-    [canUseVoice, handleReplay, speaking, speakingMessageId]
+    [canSpeak, handleReplay, speaking, speakingMessageId]
   );
 
   return (

--- a/client/src/hooks/useVoiceChat.js
+++ b/client/src/hooks/useVoiceChat.js
@@ -64,7 +64,10 @@ const useVoiceChat = () => {
   const [voiceError, setVoiceError] = useState(null);
 
   const supportsFullDuplex = useMemo(() => detectFullDuplexSupport(), []);
-  const canUseVoice = Boolean(Recognition) && typeof window !== "undefined" && "speechSynthesis" in window;
+  const hasSpeechSynthesis =
+    typeof window !== "undefined" && typeof window.speechSynthesis !== "undefined";
+  const canSpeak = hasSpeechSynthesis;
+  const canUseVoice = Boolean(Recognition) && hasSpeechSynthesis;
 
   const resetTranscript = useCallback(() => {
     setLastTranscript("");
@@ -223,11 +226,17 @@ const useVoiceChat = () => {
 
   const speak = useCallback(
     (text, options = {}) => {
-      if (!canUseVoice || !text) {
+      if (!canSpeak || !text) {
         return null;
       }
 
-      window.speechSynthesis.cancel();
+      const synth = window?.speechSynthesis;
+
+      if (!synth) {
+        return null;
+      }
+
+      synth.cancel();
 
       const utterance = new SpeechSynthesisUtterance(text);
 
@@ -265,10 +274,10 @@ const useVoiceChat = () => {
       utterance.oncancel = handleFinish;
       utterance.onerror = handleFinish;
 
-      window.speechSynthesis.speak(utterance);
+      synth.speak(utterance);
       return utterance;
     },
-    [canUseVoice]
+    [canSpeak]
   );
 
   useEffect(() => () => {
@@ -282,6 +291,7 @@ const useVoiceChat = () => {
 
   return {
     canUseVoice,
+    canSpeak,
     listening,
     startListening,
     stopListening,

--- a/client/src/pages/VoiceScreen.jsx
+++ b/client/src/pages/VoiceScreen.jsx
@@ -19,6 +19,7 @@ const VoiceScreen = () => {
   const { messages } = useChatMessages();
   const {
     canUseVoice,
+    canSpeak,
     listening,
     startListening,
     stopListening,
@@ -258,7 +259,7 @@ const VoiceScreen = () => {
   ]);
 
   useEffect(() => {
-    if (!messages.length || !canUseVoice) {
+    if (!messages.length || !canSpeak) {
       return;
     }
 
@@ -313,7 +314,7 @@ const VoiceScreen = () => {
     });
   }, [
     activeUtteranceRef,
-    canUseVoice,
+    canSpeak,
     lastSpokenRef,
     messages,
     setSpeaking,

--- a/client/src/state/voice/VoiceProvider.jsx
+++ b/client/src/state/voice/VoiceProvider.jsx
@@ -30,6 +30,7 @@ const VoiceProvider = ({ children }) => {
 
   const {
     canUseVoice,
+    canSpeak,
     listening,
     startListening,
     stopListening,
@@ -288,6 +289,7 @@ const VoiceProvider = ({ children }) => {
   const value = useMemo(
     () => ({
       canUseVoice,
+      canSpeak,
       listening,
       startListening,
       stopListening,
@@ -313,6 +315,7 @@ const VoiceProvider = ({ children }) => {
     [
       abortActiveRequest,
       canUseVoice,
+      canSpeak,
       currentRequestId,
       interrupt,
       isSending,


### PR DESCRIPTION
## Summary
- allow text-to-speech to work whenever speech synthesis is available, even if recognition APIs are missing
- expose the new speech capability through the voice provider and update chat surfaces to use it for auto-playback and replay buttons

## Testing
- npm run test:client -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d632f25eec8330a6f702a570792193