### PR TITLE
Restructure frontend into public website + protected app layouts

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,16 +1,17 @@
 import React from "react";
-import {
-  BrowserRouter,
-  Navigate,
-  Route,
-  Routes,
-  useLocation,
-} from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { useAppSelector } from "./store/store.js";
 import { selectAuthToken } from "./store/ui/uiSlice.js";
 import { useCurrentUserQuery } from "./features/auth/hooks/useAuth.js";
-import Header from "./components/Header/Header.jsx";
-import Footer from "./components/Footer/Footer.jsx";
+import PublicLayout from "./layouts/PublicLayout/PublicLayout.jsx";
+import AppLayout from "./layouts/AppLayout/AppLayout.jsx";
+import ProtectedRoute from "./routes/ProtectedRoute.jsx";
+import PublicOnlyRoute from "./routes/PublicOnlyRoute.jsx";
+import Home from "./pages/Home/Home.jsx";
+import About from "./pages/About/About.jsx";
+import Privacy from "./pages/Privacy/Privacy.jsx";
+import Terms from "./pages/Terms/Terms.jsx";
+import Contact from "./pages/Contact/Contact.jsx";
 import Profile from "./pages/Profile.jsx";
 import Onboarding from "./pages/Onboarding/Onboarding.jsx";
 import Chat from "./pages/Chat.jsx";
@@ -32,174 +33,59 @@ import JournalDetail from "./pages/JournalDetail.jsx";
 import VoiceScreen from "./pages/VoiceScreen.jsx";
 
 const AppShell = ({ isAuthenticated }) => {
-  const location = useLocation();
-  const hideChrome = location.pathname === "/voice";
-
   return (
-    <div className="app dark">
-      {isAuthenticated && !hideChrome && <Header />}
-      <Routes>
-        <Route path="/" element={<Login />} />
+    <Routes>
+      <Route element={<PublicLayout />}>
+        <Route path="/" element={<Home />} />
+        <Route path="/about" element={<About />} />
+        <Route path="/privacy" element={<Privacy />} />
+        <Route path="/terms" element={<Terms />} />
+        <Route path="/contact" element={<Contact />} />
+
         <Route
-          path="/login"
           element={
-            isAuthenticated ? <Navigate to="/chat" replace /> : <Login />
+            <PublicOnlyRoute
+              isAuthenticated={isAuthenticated}
+              redirectTo="/dashboard"
+            />
           }
-        />
-        <Route
-          path="/register"
-          element={
-            isAuthenticated ? (
-              <Navigate to="/dashboard" replace />
-            ) : (
-              <Register />
-            )
-          }
-        />
-        <Route
-          path="/dashboard"
-          element={
-            isAuthenticated ? <Dashboard /> : <Navigate to="/login" replace />
-          }
-        />
-        <Route
-          path="/admin"
-          element={
-            isAuthenticated ? (
-              <AdminDashboard />
-            ) : (
-              <Navigate to="/login" replace />
-            )
-          }
-        />
-        <Route
-          path="/chat"
-          element={
-            isAuthenticated ? <Chat /> : <Navigate to="/login" replace />
-          }
-        />
-        <Route
-          path="/voice"
-          element={
-            isAuthenticated ? <VoiceScreen /> : <Navigate to="/login" replace />
-          }
-        />
-        <Route
-          path="/faceoff"
-          element={
-            isAuthenticated ? <FaceOffPage /> : <Navigate to="/login" replace />
-          }
-        />
-        <Route
-          path="/store"
-          element={
-            isAuthenticated ? <Store /> : <Navigate to="/login" replace />
-          }
-        />
-        <Route
-          path="/store/:id"
-          element={
-            isAuthenticated ? <ItemDetails /> : <Navigate to="/login" replace />
-          }
-        />
-        <Route
-          path="/cart"
-          element={
-            isAuthenticated ? <Cart /> : <Navigate to="/login" replace />
-          }
-        />
-        <Route
-          path="/checkout"
-          element={
-            isAuthenticated ? <Checkout /> : <Navigate to="/login" replace />
-          }
-        />
-        <Route
-          path="/appointments"
-          element={
-            isAuthenticated ? (
-              <AppointmentBrowse />
-            ) : (
-              <Navigate to="/login" replace />
-            )
-          }
-        />
-        <Route
-          path="/appointments/mine"
-          element={
-            isAuthenticated ? (
-              <MyAppointments />
-            ) : (
-              <Navigate to="/login" replace />
-            )
-          }
-        />
-        <Route
-          path="/journals"
-          element={
-            isAuthenticated ? (
-              <JournalsList />
-            ) : (
-              <Navigate to="/login" replace />
-            )
-          }
-        />
-        <Route
-          path="/journals/new"
-          element={
-            isAuthenticated ? (
-              <JournalForm mode="create" />
-            ) : (
-              <Navigate to="/login" replace />
-            )
-          }
-        />
-        <Route
-          path="/journals/:id"
-          element={
-            isAuthenticated ? (
-              <JournalDetail />
-            ) : (
-              <Navigate to="/login" replace />
-            )
-          }
-        />
-        <Route
-          path="/journals/:id/edit"
-          element={
-            isAuthenticated ? (
-              <JournalForm mode="edit" />
-            ) : (
-              <Navigate to="/login" replace />
-            )
-          }
-        />
-        <Route
-          path="/appointments/:id"
-          element={
-            isAuthenticated ? (
-              <AppointmentMidwife />
-            ) : (
-              <Navigate to="/login" replace />
-            )
-          }
-        />
-        <Route
-          path="/profile"
-          element={
-            isAuthenticated ? <Profile /> : <Navigate to="/login" replace />
-          }
-        />
-        <Route path="/welcome" element={<Navigate to="/profile" replace />} />
-        <Route
-          path="/onboarding"
-          element={
-            isAuthenticated ? <Onboarding /> : <Navigate to="/login" replace />
-          }
-        />
-      </Routes>
-      {isAuthenticated && !hideChrome && <Footer />}
-    </div>
+        >
+          <Route path="/login" element={<Login />} />
+          <Route path="/register" element={<Register />} />
+        </Route>
+      </Route>
+
+      <Route
+        element={<ProtectedRoute isAuthenticated={isAuthenticated} redirectTo="/login" />}
+      >
+        <Route element={<AppLayout />}>
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/admin" element={<AdminDashboard />} />
+          <Route path="/chat" element={<Chat />} />
+          <Route path="/voice" element={<VoiceScreen />} />
+          <Route path="/faceoff" element={<FaceOffPage />} />
+          <Route path="/store" element={<Store />} />
+          <Route path="/store/:id" element={<ItemDetails />} />
+          <Route path="/cart" element={<Cart />} />
+          <Route path="/checkout" element={<Checkout />} />
+          <Route path="/appointments" element={<AppointmentBrowse />} />
+          <Route path="/appointments/mine" element={<MyAppointments />} />
+          <Route path="/appointments/:id" element={<AppointmentMidwife />} />
+          <Route path="/journals" element={<JournalsList />} />
+          <Route path="/journals/new" element={<JournalForm mode="create" />} />
+          <Route path="/journals/:id" element={<JournalDetail />} />
+          <Route path="/journals/:id/edit" element={<JournalForm mode="edit" />} />
+          <Route path="/profile" element={<Profile />} />
+          <Route path="/onboarding" element={<Onboarding />} />
+          <Route path="/welcome" element={<Navigate to="/profile" replace />} />
+        </Route>
+      </Route>
+
+      <Route
+        path="*"
+        element={<Navigate to={isAuthenticated ? "/dashboard" : "/"} replace />}
+      />
+    </Routes>
   );
 };
 

--- a/client/src/components/Footer/Footer.jsx
+++ b/client/src/components/Footer/Footer.jsx
@@ -1,46 +1,40 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import "./footer.styles.scss";
 
-const Footer = () => {
-  return (
-    <footer className="footer">
-      <div className="footer-content">
-        <p className="footer-text">
-          Created by{" "}
-          <a
-            href="https://github.com/kofiarhin"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Kofi Arhin
-          </a>
-        </p>
-        <div className="social-links">
-          <a
-            href="https://github.com/kofiarhin"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="social-link"
-          >
-            GitHub
-          </a>
-          <a
-            href="https://www.instagram.com/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="social-link"
-          >
-            Instagram
-          </a>
-          <a
-            href="https://x.com/kwofiArhin"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="social-link"
-          >
-            Twitter
-          </a>
+const Footer = ({ variant = "public" }) => {
+  if (variant === "app") {
+    return (
+      <footer className="footer app-footer">
+        <div className="footer-content container">
+          <p className="footer-text">
+            PregChat · Educational support only — not a diagnosis.
+          </p>
         </div>
+      </footer>
+    );
+  }
+
+  return (
+    <footer className="footer public-footer">
+      <div className="footer-content container">
+        <div>
+          <p className="footer-brand">PregChat</p>
+          <p className="footer-text">
+            A calm, supportive pregnancy companion for every day of your
+            journey.
+          </p>
+        </div>
+
+        <nav className="footer-links" aria-label="Footer links">
+          <Link to="/">Home</Link>
+          <Link to="/about">About</Link>
+          <Link to="/login">Login</Link>
+          <Link to="/register">Register</Link>
+          <Link to="/privacy">Privacy</Link>
+          <Link to="/terms">Terms</Link>
+          <Link to="/contact">Contact</Link>
+        </nav>
       </div>
     </footer>
   );

--- a/client/src/components/Footer/footer.styles.scss
+++ b/client/src/components/Footer/footer.styles.scss
@@ -1,63 +1,57 @@
 .footer {
-  background-color: #0d0d0d;
-  border-top: 1px solid #1f1f1f;
-  padding: 1rem 0;
   margin-top: auto;
-  width: 100%;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  background: #090d1f;
+}
 
+.footer-content {
+  padding: 1.5rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.footer-brand {
+  font-size: 1.05rem;
+  color: #fff;
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+}
+
+.footer-text {
+  color: #c9c5d1;
+  font-size: 0.9rem;
+}
+
+.footer-links {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
+.footer-links a {
+  color: #e8dfed;
+  text-decoration: none;
+  font-size: 0.88rem;
+}
+
+.footer-links a:hover {
+  color: #fff;
+}
+
+.app-footer {
+  background: #05070f;
+}
+
+@media (min-width: 900px) {
   .footer-content {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 1rem;
-    display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    justify-content: space-between;
     align-items: center;
-    gap: 0.5rem;
-
-    @media (min-width: 768px) {
-      flex-direction: row;
-      justify-content: space-between;
-    }
   }
 
-  .footer-text {
-    margin: 0;
-    font-size: 0.875rem;
-    color: #a6adba;
-    text-align: center;
-
-    @media (min-width: 768px) {
-      text-align: left;
-    }
-
-    a {
-      color: #4c8bf5;
-      text-decoration: none;
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
-
-    span {
-      font-weight: 500;
-    }
-  }
-
-  .social-links {
-    display: flex;
+  .footer-links {
+    grid-template-columns: repeat(4, minmax(0, auto));
     gap: 1rem;
-
-    .social-link {
-      color: #8b92a0;
-      text-decoration: none;
-      font-size: 0.875rem;
-      transition: color 0.2s ease;
-
-      &:hover {
-        color: #4c8bf5;
-        text-decoration: underline;
-      }
-    }
   }
 }

--- a/client/src/components/PublicHeader/PublicHeader.jsx
+++ b/client/src/components/PublicHeader/PublicHeader.jsx
@@ -1,0 +1,91 @@
+import React, { useMemo, useState } from "react";
+import { Link, NavLink, useLocation } from "react-router-dom";
+import { FaBars, FaTimes } from "react-icons/fa";
+import "./public-header.styles.scss";
+
+const PUBLIC_NAV_LINKS = [
+  { id: "home", label: "Home", path: "/" },
+  { id: "about", label: "About", path: "/about" },
+  { id: "login", label: "Login", path: "/login" },
+  { id: "register", label: "Register", path: "/register", cta: true },
+];
+
+const PublicHeader = () => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const location = useLocation();
+
+  const mobileLinks = useMemo(() => PUBLIC_NAV_LINKS, []);
+
+  const closeMenu = () => setIsMenuOpen(false);
+  const toggleMenu = () => setIsMenuOpen((prev) => !prev);
+
+  React.useEffect(() => {
+    closeMenu();
+  }, [location.pathname]);
+
+  return (
+    <header className="public-header" role="banner">
+      <div className="public-header-inner container">
+        <Link to="/" className="public-brand" aria-label="PregChat home">
+          PregChat
+        </Link>
+
+        <nav className="public-nav" aria-label="Public">
+          {PUBLIC_NAV_LINKS.map((link) => (
+            <NavLink
+              key={link.id}
+              to={link.path}
+              className={({ isActive }) =>
+                `public-nav-link ${isActive ? "active" : ""} ${
+                  link.cta ? "public-nav-cta" : ""
+                }`
+              }
+            >
+              {link.label}
+            </NavLink>
+          ))}
+        </nav>
+
+        <button
+          type="button"
+          className="public-menu-btn"
+          onClick={toggleMenu}
+          aria-label="Toggle navigation"
+          aria-expanded={isMenuOpen}
+          aria-controls="public-mobile-nav"
+        >
+          {isMenuOpen ? <FaTimes /> : <FaBars />}
+        </button>
+      </div>
+
+      <div
+        className={`public-overlay ${isMenuOpen ? "show" : ""}`}
+        role="presentation"
+        onClick={closeMenu}
+      />
+
+      <aside
+        id="public-mobile-nav"
+        className={`public-mobile-nav ${isMenuOpen ? "open" : ""}`}
+        aria-hidden={!isMenuOpen}
+      >
+        <p className="public-mobile-title">Navigate</p>
+        <nav aria-label="Mobile public navigation">
+          {mobileLinks.map((link) => (
+            <NavLink
+              key={link.id}
+              to={link.path}
+              className={({ isActive }) =>
+                `public-mobile-link ${isActive ? "active" : ""}`
+              }
+            >
+              {link.label}
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+    </header>
+  );
+};
+
+export default PublicHeader;

--- a/client/src/components/PublicHeader/public-header.styles.scss
+++ b/client/src/components/PublicHeader/public-header.styles.scss
@@ -1,0 +1,128 @@
+.public-header {
+  position: sticky;
+  top: 0;
+  z-index: 70;
+  background: rgba(7, 10, 22, 0.92);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(10px);
+}
+
+.public-header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 72px;
+}
+
+.public-brand {
+  color: #f6f2f2;
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 1.2rem;
+  letter-spacing: 0.02em;
+}
+
+.public-nav {
+  display: none;
+  gap: 0.5rem;
+}
+
+.public-nav-link {
+  color: #d9d4df;
+  text-decoration: none;
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease;
+}
+
+.public-nav-link.active,
+.public-nav-link:hover {
+  background: rgba(197, 168, 233, 0.18);
+  color: #fff;
+}
+
+.public-nav-cta {
+  border: 1px solid rgba(224, 191, 145, 0.45);
+}
+
+.public-menu-btn {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.public-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.public-overlay.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.public-mobile-nav {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(300px, 86vw);
+  height: 100vh;
+  padding: 2rem 1.25rem;
+  background: #0c1024;
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+  transform: translateX(100%);
+  transition: transform 0.25s ease;
+  z-index: 80;
+}
+
+.public-mobile-nav.open {
+  transform: translateX(0);
+}
+
+.public-mobile-title {
+  color: #e8e5ec;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.public-mobile-link {
+  display: block;
+  color: #dcd6e5;
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 0.8rem 0.95rem;
+}
+
+.public-mobile-link + .public-mobile-link {
+  margin-top: 0.65rem;
+}
+
+.public-mobile-link.active {
+  color: #fff;
+  border-color: rgba(214, 182, 140, 0.8);
+}
+
+@media (min-width: 900px) {
+  .public-nav {
+    display: flex;
+  }
+
+  .public-menu-btn,
+  .public-overlay,
+  .public-mobile-nav {
+    display: none;
+  }
+}

--- a/client/src/layouts/AppLayout/AppLayout.jsx
+++ b/client/src/layouts/AppLayout/AppLayout.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Outlet, useLocation } from "react-router-dom";
+import Header from "../../components/Header/Header.jsx";
+import Footer from "../../components/Footer/Footer.jsx";
+
+const AppLayout = () => {
+  const location = useLocation();
+  const hideChrome = location.pathname === "/voice";
+
+  return (
+    <div className="app dark">
+      {!hideChrome && <Header />}
+      <Outlet />
+      {!hideChrome && <Footer variant="app" />}
+    </div>
+  );
+};
+
+export default AppLayout;

--- a/client/src/layouts/PublicLayout/PublicLayout.jsx
+++ b/client/src/layouts/PublicLayout/PublicLayout.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Outlet } from "react-router-dom";
+import PublicHeader from "../../components/PublicHeader/PublicHeader.jsx";
+import Footer from "../../components/Footer/Footer.jsx";
+import "./public-layout.styles.scss";
+
+const PublicLayout = () => {
+  return (
+    <div className="public-layout">
+      <PublicHeader />
+      <main className="public-main" id="app-content">
+        <Outlet />
+      </main>
+      <Footer variant="public" />
+    </div>
+  );
+};
+
+export default PublicLayout;

--- a/client/src/layouts/PublicLayout/public-layout.styles.scss
+++ b/client/src/layouts/PublicLayout/public-layout.styles.scss
@@ -1,0 +1,11 @@
+.public-layout {
+  min-height: 100vh;
+  background: radial-gradient(circle at top right, #241b36 0%, #0b1020 40%, #070910 100%);
+  color: #f2eff6;
+  display: flex;
+  flex-direction: column;
+}
+
+.public-main {
+  flex: 1;
+}

--- a/client/src/pages/About/About.jsx
+++ b/client/src/pages/About/About.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import "./about.styles.scss";
+
+const About = () => {
+  return (
+    <div className="about-page container">
+      <section>
+        <p className="about-kicker">About PregChat</p>
+        <h1>A calmer way to feel supported through pregnancy.</h1>
+        <p>
+          PregChat is built to help expecting mothers feel informed and cared
+          for day by day. We believe guidance should feel clear, supportive, and
+          easy to access whenever questions come up.
+        </p>
+      </section>
+
+      <section className="about-card-grid">
+        <article>
+          <h2>What PregChat is</h2>
+          <p>
+            PregChat brings together daily updates, supportive chat guidance,
+            journals, and planning tools in one focused space for pregnancy.
+          </p>
+        </article>
+        <article>
+          <h2>Who it is for</h2>
+          <p>
+            It is designed primarily for expecting mothers and can also support
+            partners or family members who want to follow the journey with care.
+          </p>
+        </article>
+        <article>
+          <h2>Our mission</h2>
+          <p>
+            To offer calm, simple, supportive pregnancy guidance that helps each
+            day feel a little more manageable and a little more connected.
+          </p>
+        </article>
+      </section>
+    </div>
+  );
+};
+
+export default About;

--- a/client/src/pages/About/about.styles.scss
+++ b/client/src/pages/About/about.styles.scss
@@ -1,0 +1,47 @@
+.about-page {
+  padding: 2.5rem 1rem 4rem;
+}
+
+.about-kicker {
+  color: #dbc39d;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.78rem;
+  margin-bottom: 0.8rem;
+}
+
+.about-page h1 {
+  color: #fff;
+  max-width: 16ch;
+  line-height: 1.1;
+  margin-bottom: 1rem;
+}
+
+.about-page p {
+  color: #d4cfde;
+  max-width: 70ch;
+}
+
+.about-card-grid {
+  margin-top: 2rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.about-card-grid article {
+  padding: 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.about-card-grid h2 {
+  color: #f4eff8;
+  margin-bottom: 0.5rem;
+}
+
+@media (min-width: 900px) {
+  .about-card-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/client/src/pages/Contact/Contact.jsx
+++ b/client/src/pages/Contact/Contact.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const Contact = () => {
+  return (
+    <section className="container" style={{ padding: "2rem 1rem" }}>
+      <h1>Contact</h1>
+      <p>Reach us at support@pregchat.app for help and feedback.</p>
+    </section>
+  );
+};
+
+export default Contact;

--- a/client/src/pages/Home/Home.jsx
+++ b/client/src/pages/Home/Home.jsx
@@ -1,12 +1,174 @@
-import React from "react";
-import { useAuth } from "@clerk/clerk-react";
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import { FaChevronDown } from "react-icons/fa";
 import "./home.styles.scss";
+
+const FAQ_ITEMS = [
+  {
+    question: "Is PregChat only for pregnant women?",
+    answer:
+      "PregChat is designed primarily for expecting mothers, but supportive family members may also find it helpful.",
+  },
+  {
+    question: "Can I track my pregnancy progress daily?",
+    answer:
+      "Yes. PregChat is designed to help users follow their pregnancy journey with day-by-day support and updates.",
+  },
+  {
+    question: "Do I need medical knowledge to use it?",
+    answer:
+      "No. The experience is designed to be simple, clear, and easy to understand.",
+  },
+  {
+    question: "Can I use PregChat on my phone?",
+    answer:
+      "Yes. The platform should feel smooth and accessible across devices.",
+  },
+  {
+    question: "Is my information private?",
+    answer:
+      "PregChat is designed with a private, personal experience in mind.",
+  },
+];
+
 const Home = () => {
-  const { user } = useAuth();
+  const [openFaq, setOpenFaq] = useState(0);
+
   return (
-    <div id="home">
-      <h1>Testing Mic</h1>{" "}
-      {user ? <p> user details here</p> : <p> pleade log in</p>}{" "}
+    <div className="home-page">
+      <section className="hero container">
+        <div>
+          <p className="kicker">A calm, supportive pregnancy companion</p>
+          <h1>Your pregnancy companion, one chat away.</h1>
+          <p className="hero-copy">
+            Get daily pregnancy guidance, supportive answers, and a calm space
+            to track your journey — all in one place.
+          </p>
+          <div className="hero-actions">
+            <Link to="/register" className="btn btn-primary">
+              Get Started
+            </Link>
+            <Link to="/about" className="btn btn-ghost">
+              Learn More
+            </Link>
+          </div>
+          <p className="hero-microcopy">
+            Built for expecting mothers who want simple, supportive, day-by-day
+            pregnancy help.
+          </p>
+        </div>
+
+        <div className="hero-visual" aria-hidden="true">
+          <div className="hero-device">
+            <p className="hero-device-title">Today in PregChat</p>
+            <p className="hero-device-text">
+              Baby update: tiny growth, stronger heartbeat, and one step closer
+              to meeting your little one.
+            </p>
+            <p className="hero-device-bubble">
+              “I have a new symptom today — should I monitor it?”
+            </p>
+            <p className="hero-device-reply">
+              Aya: I’m here with you. Let’s walk through what you’re feeling,
+              and what to do next.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="trust-strip container">
+        {[
+          "Personalized pregnancy support",
+          "Daily progress insights",
+          "Calm, easy-to-use experience",
+          "Designed for your motherhood journey",
+        ].map((item) => (
+          <article key={item} className="trust-card">
+            {item}
+          </article>
+        ))}
+      </section>
+
+      <section className="content-section container">
+        <h2>What is PregChat?</h2>
+        <p>
+          PregChat is a pregnancy-focused support platform designed to help
+          expecting mothers stay informed, reassured, and connected throughout
+          the journey. From daily baby development updates to guidance about the
+          changes happening in your body, PregChat gives you a simple place to
+          check in, learn, and feel supported.
+        </p>
+      </section>
+
+      <section className="content-section container">
+        <h2>Everything you need in one supportive space.</h2>
+        <div className="feature-grid">
+          <article className="feature-card"><h3>Daily Pregnancy Updates</h3><p>Follow your pregnancy day by day with simple, meaningful updates about your baby’s growth and your body’s changes.</p></article>
+          <article className="feature-card"><h3>Chat-Based Guidance</h3><p>Ask questions in a natural way and get supportive, relevant answers when you need them.</p></article>
+          <article className="feature-card"><h3>Personal Journey Tracking</h3><p>Keep your pregnancy experience organized with progress-based insights and personal check-ins.</p></article>
+          <article className="feature-card"><h3>Calm, Private Experience</h3><p>A focused space designed to feel reassuring, simple, and easy to use.</p></article>
+          <article className="feature-card"><h3>Journals and Reflections</h3><p>Capture your thoughts, milestones, and emotions throughout pregnancy.</p></article>
+          <article className="feature-card"><h3>Appointments and Planning</h3><p>Stay on top of important moments, reminders, and next steps.</p></article>
+        </div>
+      </section>
+
+      <section className="content-section container">
+        <h2>Simple from the start.</h2>
+        <div className="steps-grid">
+          <article><span>Step 1</span><h3>Create your account</h3><p>Get started in minutes.</p></article>
+          <article><span>Step 2</span><h3>Add your pregnancy details</h3><p>Help PregChat personalize your experience.</p></article>
+          <article><span>Step 3</span><h3>Receive support every day</h3><p>Track progress, ask questions, and stay connected.</p></article>
+        </div>
+      </section>
+
+      <section className="content-section container tone-panel">
+        <h2>You do not have to figure it all out alone.</h2>
+        <p>
+          Pregnancy can bring excitement, questions, uncertainty, and change.
+          PregChat gives you a supportive digital space where guidance feels
+          easier to access and your journey feels easier to follow.
+        </p>
+      </section>
+
+      <section className="content-section container">
+        <h2>Who PregChat is for</h2>
+        <ul className="who-list">
+          <li>First-time moms looking for guidance</li>
+          <li>Expecting mothers who want daily support</li>
+          <li>Families who want a more organized pregnancy journey</li>
+          <li>Anyone who wants a calmer, simpler way to stay informed</li>
+        </ul>
+      </section>
+
+      <section className="content-section container">
+        <h2>Frequently asked questions</h2>
+        <div className="faq-list">
+          {FAQ_ITEMS.map((item, index) => {
+            const isOpen = openFaq === index;
+            return (
+              <article key={item.question} className="faq-item">
+                <button type="button" onClick={() => setOpenFaq(isOpen ? -1 : index)}>
+                  <span>{item.question}</span>
+                  <FaChevronDown className={isOpen ? "open" : ""} />
+                </button>
+                {isOpen && <p>{item.answer}</p>}
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="content-section container final-cta">
+        <h2>Start your journey with PregChat today.</h2>
+        <p>
+          Create your account and experience a simpler, calmer way to stay
+          connected throughout pregnancy.
+        </p>
+        <div className="hero-actions">
+          <Link to="/register" className="btn btn-primary">Register</Link>
+          <Link to="/login" className="btn btn-ghost">Login</Link>
+        </div>
+      </section>
     </div>
   );
 };

--- a/client/src/pages/Home/home.styles.scss
+++ b/client/src/pages/Home/home.styles.scss
@@ -1,0 +1,223 @@
+.home-page {
+  padding-bottom: 3rem;
+}
+
+.hero {
+  display: grid;
+  gap: 1.5rem;
+  padding-top: 2.5rem;
+}
+
+.kicker {
+  color: #dbc39d;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.75rem;
+  margin-bottom: 0.8rem;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  line-height: 1.1;
+  max-width: 12ch;
+  color: #fff;
+}
+
+.hero-copy {
+  margin-top: 0.9rem;
+  color: #d6d2de;
+  max-width: 52ch;
+}
+
+.hero-microcopy {
+  margin-top: 1rem;
+  color: #b6b0c2;
+  font-size: 0.92rem;
+}
+
+.hero-actions {
+  margin-top: 1.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.btn-primary {
+  background: linear-gradient(120deg, #be90e5 0%, #e7b882 100%);
+  color: #170f1f;
+  font-weight: 700;
+}
+
+.btn-ghost {
+  background: transparent;
+  color: #ebe5f3;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+}
+
+.hero-visual {
+  border-radius: 20px;
+  padding: 1rem;
+  background: radial-gradient(circle at 30% 10%, rgba(228, 178, 229, 0.22), transparent 65%), rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.hero-device {
+  border-radius: 16px;
+  padding: 1rem;
+  background: #10162d;
+}
+
+.hero-device-title {
+  color: #fff;
+  font-weight: 600;
+}
+
+.hero-device-text,
+.hero-device-reply {
+  color: #cec7db;
+  margin-top: 0.75rem;
+  font-size: 0.92rem;
+}
+
+.hero-device-bubble {
+  margin-top: 0.75rem;
+  padding: 0.8rem;
+  border-radius: 14px;
+  color: #efe8f6;
+  background: rgba(197, 164, 233, 0.18);
+}
+
+.trust-strip {
+  margin-top: 2rem;
+  display: grid;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.trust-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 0.9rem;
+  color: #e7e1ee;
+}
+
+.content-section {
+  margin-top: 3rem;
+}
+
+.content-section h2 {
+  color: #fff;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  margin-bottom: 0.9rem;
+}
+
+.content-section p {
+  color: #d2cddc;
+  max-width: 75ch;
+}
+
+.feature-grid,
+.steps-grid {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.feature-card,
+.steps-grid article,
+.faq-item {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 14px;
+  padding: 1rem;
+}
+
+.feature-card h3,
+.steps-grid h3 {
+  color: #f4eef8;
+  margin-bottom: 0.55rem;
+}
+
+.steps-grid span {
+  display: inline-block;
+  margin-bottom: 0.45rem;
+  color: #d9b886;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+}
+
+.tone-panel {
+  border: 1px solid rgba(216, 180, 146, 0.35);
+  border-radius: 16px;
+  padding: 1.2rem;
+  background: rgba(230, 181, 144, 0.05);
+}
+
+.who-list {
+  display: grid;
+  gap: 0.7rem;
+  color: #dbd5e7;
+  padding-left: 1.1rem;
+}
+
+.faq-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.faq-item button {
+  width: 100%;
+  text-align: left;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #fff;
+  background: transparent;
+  border: none;
+  font-size: 0.95rem;
+}
+
+.faq-item svg {
+  transition: transform 0.2s ease;
+}
+
+.faq-item svg.open {
+  transform: rotate(180deg);
+}
+
+.faq-item p {
+  margin-top: 0.65rem;
+}
+
+.final-cta {
+  text-align: center;
+  border-radius: 18px;
+  background: rgba(185, 142, 215, 0.09);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 1.4rem;
+}
+
+.final-cta .hero-actions {
+  justify-content: center;
+}
+
+@media (min-width: 900px) {
+  .hero {
+    grid-template-columns: 1.1fr 1fr;
+    align-items: center;
+    min-height: 78vh;
+  }
+
+  .trust-strip {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .feature-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .steps-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,62 +1,17 @@
 import React, { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useLoginMutation } from "../features/auth/hooks/useAuth.js";
-
-const loginStyles = {
-  wrapper: {
-    minHeight: "100vh",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    background:
-      "radial-gradient(circle at top, #181818 0%, #090909 55%, #020202 100%)",
-    padding: "1rem",
-  },
-  card: {
-    background: "#141414",
-    border: "1px solid #1f1f1f",
-    padding: "2rem",
-    borderRadius: "1rem",
-    boxShadow: "0 16px 40px rgba(0, 0, 0, 0.55)",
-    width: "100%",
-    maxWidth: "400px",
-  },
-  header: { textAlign: "center", marginBottom: "2rem" },
-  title: { color: "#f5f7ff", marginBottom: "0.5rem" },
-  subtitle: { color: "#a0a5b4", marginBottom: "0.5rem" },
-  field: { marginBottom: "1rem" },
-  label: {
-    display: "block",
-    marginBottom: "0.5rem",
-    fontWeight: "500",
-    color: "#d0d3dc",
-  },
-  error: {
-    background: "#3a1212",
-    color: "#ffd6d6",
-    padding: "0.75rem",
-    borderRadius: "0.25rem",
-    marginBottom: "1rem",
-    fontSize: "0.875rem",
-    border: "1px solid #5b1c1c",
-  },
-  cta: {
-    textAlign: "center",
-    fontSize: "0.875rem",
-    color: "#9aa0a6",
-  },
-  link: { color: "#4c8bf5" },
-};
+import "./login.styles.scss";
 
 const Login = () => {
   const navigate = useNavigate();
   const [formData, setFormData] = useState({
-    email: "kofiarhin@gmail.com",
-    password: "password",
+    email: "",
+    password: "",
   });
 
   const loginMutation = useLoginMutation({
-    // onSuccess: () => navigate("/chat", { replace: true }),
+    onSuccess: () => navigate("/dashboard", { replace: true }),
   });
 
   const handleChange = (event) => {
@@ -69,23 +24,20 @@ const Login = () => {
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    loginMutation.mutate({
-      email: formData.email,
-      password: formData.password,
-    });
+    loginMutation.mutate(formData);
   };
 
   return (
-    <div style={loginStyles.wrapper}>
-      <div style={loginStyles.card}>
-        <div style={loginStyles.header}>
-          <h1 style={loginStyles.title}>Welcome Back!</h1>
-          <p style={loginStyles.subtitle}>Sign in to PregChat</p>
-        </div>
+    <main className="auth-page">
+      <section className="auth-card">
+        <header className="auth-header">
+          <h1 className="auth-title">Welcome back</h1>
+          <p className="auth-subtitle">Sign in to continue your PregChat journey.</p>
+        </header>
 
         <form onSubmit={handleSubmit}>
-          <div style={loginStyles.field}>
-            <label htmlFor="email" style={loginStyles.label}>
+          <div className="auth-field">
+            <label htmlFor="email" className="auth-label">
               Email
             </label>
             <input
@@ -99,8 +51,8 @@ const Login = () => {
             />
           </div>
 
-          <div style={{ ...loginStyles.field, marginBottom: "1.5rem" }}>
-            <label htmlFor="password" style={loginStyles.label}>
+          <div className="auth-field">
+            <label htmlFor="password" className="auth-label">
               Password
             </label>
             <input
@@ -115,27 +67,19 @@ const Login = () => {
           </div>
 
           {loginMutation.isError && (
-            <div style={loginStyles.error}>{loginMutation.error?.message}</div>
+            <div className="auth-error">{loginMutation.error?.message}</div>
           )}
 
-          <button
-            type="submit"
-            className="btn"
-            style={{ width: "100%", marginBottom: "1rem" }}
-            disabled={loginMutation.isPending}
-          >
+          <button type="submit" className="btn auth-submit" disabled={loginMutation.isPending}>
             {loginMutation.isPending ? "Loading..." : "Login"}
           </button>
         </form>
 
-        <p style={loginStyles.cta}>
-          Don't have an account?{" "}
-          <Link to="/register" style={loginStyles.link}>
-            Register
-          </Link>
+        <p className="auth-cta">
+          Don&apos;t have an account? <Link to="/register">Register</Link>
         </p>
-      </div>
-    </div>
+      </section>
+    </main>
   );
 };
 

--- a/client/src/pages/Privacy/Privacy.jsx
+++ b/client/src/pages/Privacy/Privacy.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+const Privacy = () => {
+  return (
+    <section className="container" style={{ padding: "2rem 1rem" }}>
+      <h1>Privacy</h1>
+      <p>
+        PregChat is designed with a private, personal experience in mind. Please
+        contact support for details about data handling in your region.
+      </p>
+    </section>
+  );
+};
+
+export default Privacy;

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import content from "../content/appContent.json";
-import styles from "./register.styles.module.scss";
 import { useRegisterMutation } from "../features/auth/hooks/useAuth.js";
+import "./login.styles.scss";
 
 const regionOptions = [
   { value: "", label: "Select your region" },
@@ -23,7 +23,7 @@ const Register = () => {
 
   const registerMutation = useRegisterMutation({
     onSuccess: () => {
-      navigate("/chat");
+      navigate("/dashboard", { replace: true });
     },
   });
 
@@ -44,20 +44,20 @@ const Register = () => {
   const errorMessage = registerMutation.error?.message;
 
   return (
-    <main className={styles.wrapper}>
-      <section className={styles.card}>
-        <header className={styles.header}>
-          <h1 className={styles.title}>{registerCopy.title}</h1>
-          <p className={styles.subtitle}>{registerCopy.subtitle}</p>
+    <main className="auth-page">
+      <section className="auth-card">
+        <header className="auth-header">
+          <h1 className="auth-title">{registerCopy.title}</h1>
+          <p className="auth-subtitle">{registerCopy.subtitle}</p>
         </header>
 
-        <form className={styles.form} onSubmit={handleSubmit} noValidate>
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="name">
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="name">
               {registerCopy.fields?.name}
             </label>
             <input
-              className={styles.input}
+              className="input"
               id="name"
               name="name"
               type="text"
@@ -68,12 +68,12 @@ const Register = () => {
             />
           </div>
 
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="email">
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="email">
               {registerCopy.fields?.email}
             </label>
             <input
-              className={styles.input}
+              className="input"
               id="email"
               name="email"
               type="email"
@@ -84,12 +84,12 @@ const Register = () => {
             />
           </div>
 
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="password">
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="password">
               {registerCopy.fields?.password}
             </label>
             <input
-              className={styles.input}
+              className="input"
               id="password"
               name="password"
               type="password"
@@ -100,12 +100,12 @@ const Register = () => {
             />
           </div>
 
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="region">
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="region">
               {registerCopy.fields?.region}
             </label>
             <select
-              className={styles.input}
+              className="input"
               id="region"
               name="region"
               value={formData.region}
@@ -120,18 +120,15 @@ const Register = () => {
             </select>
           </div>
 
-          {errorMessage && <div className={styles.error}>{errorMessage}</div>}
+          {errorMessage && <div className="auth-error">{errorMessage}</div>}
 
-          <button className={styles.submit} type="submit" disabled={isSubmitting}>
+          <button className="btn auth-submit" type="submit" disabled={isSubmitting}>
             {isSubmitting ? registerCopy.loading : registerCopy.submit}
           </button>
         </form>
 
-        <p className={styles.cta}>
-          {registerCopy.loginPrompt} {" "}
-          <Link className={styles.link} to="/login">
-            {registerCopy.loginLink}
-          </Link>
+        <p className="auth-cta">
+          {registerCopy.loginPrompt} <Link to="/login">{registerCopy.loginLink}</Link>
         </p>
       </section>
     </main>

--- a/client/src/pages/Terms/Terms.jsx
+++ b/client/src/pages/Terms/Terms.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+const Terms = () => {
+  return (
+    <section className="container" style={{ padding: "2rem 1rem" }}>
+      <h1>Terms</h1>
+      <p>
+        PregChat provides educational support and does not replace professional
+        medical care.
+      </p>
+    </section>
+  );
+};
+
+export default Terms;

--- a/client/src/pages/login.styles.scss
+++ b/client/src/pages/login.styles.scss
@@ -1,0 +1,59 @@
+.auth-page {
+  padding: 2.5rem 1rem 3rem;
+  display: flex;
+  justify-content: center;
+}
+
+.auth-card {
+  width: min(100%, 460px);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  padding: 1.25rem;
+}
+
+.auth-header {
+  margin-bottom: 1.2rem;
+}
+
+.auth-title {
+  color: #fff;
+  margin-bottom: 0.35rem;
+}
+
+.auth-subtitle {
+  color: #c8c1d4;
+}
+
+.auth-field {
+  margin-bottom: 0.95rem;
+}
+
+.auth-label {
+  display: block;
+  margin-bottom: 0.42rem;
+  color: #dfdae7;
+}
+
+.auth-error {
+  border-radius: 10px;
+  padding: 0.7rem;
+  margin-bottom: 0.75rem;
+  background: #3f1620;
+  border: 1px solid #6b2436;
+  color: #f8d8df;
+}
+
+.auth-submit {
+  width: 100%;
+}
+
+.auth-cta {
+  margin-top: 1rem;
+  color: #c9c3d3;
+}
+
+.auth-cta a {
+  color: #f2d7af;
+  text-decoration: none;
+}

--- a/client/src/routes/ProtectedRoute.jsx
+++ b/client/src/routes/ProtectedRoute.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Navigate, Outlet } from "react-router-dom";
+
+const ProtectedRoute = ({ isAuthenticated, redirectTo = "/login" }) => {
+  if (!isAuthenticated) {
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  return <Outlet />;
+};
+
+export default ProtectedRoute;

--- a/client/src/routes/PublicOnlyRoute.jsx
+++ b/client/src/routes/PublicOnlyRoute.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Navigate, Outlet } from "react-router-dom";
+
+const PublicOnlyRoute = ({ isAuthenticated, redirectTo = "/dashboard" }) => {
+  if (isAuthenticated) {
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  return <Outlet />;
+};
+
+export default PublicOnlyRoute;


### PR DESCRIPTION
### Motivation

- Move the experience from an auth-first entry to a site-first flow so `/` is a welcoming public homepage while preserving the authenticated PregChat app experience.
- Provide two clear layout shells so public pages do not depend on authenticated chrome, and the protected app retains its existing header/sidebar and navigation behavior.
- Keep existing authentication logic and backend integrations unchanged while making login/register feel like normal public-site pages.

### Description

- Introduced two layouts: `PublicLayout` (`client/src/layouts/PublicLayout`) for public pages and `AppLayout` (`client/src/layouts/AppLayout`) for authenticated app pages, each with its own chrome and footer variant.
- Added route wrappers `ProtectedRoute` and `PublicOnlyRoute` (`client/src/routes/`) and reworked `App.jsx` to split routing into a public tree (`/`, `/about`, `/privacy`, `/terms`, `/contact`, `/login`, `/register`) and a protected tree (all existing app routes under `AppLayout`).
- Built a responsive public navigation component `PublicHeader` with desktop links + mobile drawer (`client/src/components/PublicHeader`) and updated the `Footer` to support `public` and `app` variants.
- Replaced the stale Clerk-based home with a full public landing page (`client/src/pages/Home`) implementing the required sections (hero, trust strip, what is PregChat, features, how it works, emotional benefit, who it’s for, FAQ, final CTA) and accompanying SCSS styles, plus added `About`, `Privacy`, `Terms`, and `Contact` informational pages.
- Refactored `Login` and `Register` UI into the public shell (`client/src/pages/Login.jsx`, `client/src/pages/Register.jsx`, and `client/src/pages/login.styles.scss`) while preserving the existing `useLoginMutation`/`useRegisterMutation` flows and redirect behavior into the protected app on success.

### Testing

- Ran client unit tests with `npm run test --prefix client -- --run src/App.test.jsx`, and the tests executed successfully (`3 tests passed`).
- Built the client with `npm run build --prefix client`, and the production build completed successfully (build completed; noted chunk-size warning only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aceee1bce4833090dad7c9f6da4e1c)